### PR TITLE
Avoid IFD

### DIFF
--- a/pkgs/build-support/default.nix
+++ b/pkgs/build-support/default.nix
@@ -84,12 +84,15 @@ lib
       { }));
 
   readFirstBytes = limit: file:
-    readFile (pkgs.callPackage
-      ({ runCommandLocal }:
-        runCommandLocal (baseNameOf file) { } ''
-          head -c ${toString limit} ${file} > $out
-        '')
-      { });
+    lib.warn "You would probably want to use readElispHeaders instead"
+      (readFile (pkgs.callPackage
+        ({ runCommandLocal }:
+          runCommandLocal (baseNameOf file) { } ''
+            head -c ${toString limit} ${file} > $out
+          '')
+        { }));
+
+  readElispHeaders = pkgs.callPackage ./elisp/beforeCode.nix { };
 
   # Just a shorthand for overriding a nested attribute.
   # I am looking for a better syntax for overriding multiple packages.

--- a/pkgs/build-support/elisp/beforeCode.nix
+++ b/pkgs/build-support/elisp/beforeCode.nix
@@ -1,0 +1,14 @@
+{ runCommandLocal
+}:
+file:
+let
+  inherit (builtins) baseNameOf readFile;
+  drv = runCommandLocal (baseNameOf file) { } ''
+    set -euo pipefail
+    src="${file}"
+    pos=$(grep -E '^;+\s+Code:' --binary-files=text -b "$src" | cut -d: -f1)
+    head -c "$pos" "$src" > $out
+  '';
+in
+# This is an IFD.
+readFile drv

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -30,10 +30,10 @@ let
   # pydoc.el is an example. A workaround is to take only the first N bytes of
   # the file using `head` command and read its output.
   headers = lib.parseElispHeaders
-    (lib.readFirstBytes
+    (if self.isNonAsciiSource or false
       # magit.el has a relatively long header, so other libraries would be shorter.
-      1500
-      (self.src + "/${self.mainFile}"));
+     then lib.readFirstBytes 1500 (self.src + "/${self.mainFile}")
+     else readFile (self.src + "/${self.mainFile}"));
 in
 lib.getAttrs
   (filter (name: hasAttr name attrs) [

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -31,8 +31,7 @@ let
   # the file using `head` command and read its output.
   headers = lib.parseElispHeaders
     (if self.isNonAsciiSource or false
-      # magit.el has a relatively long header, so other libraries would be shorter.
-     then lib.readFirstBytes 1500 (self.src + "/${self.mainFile}")
+     then lib.readElispHeaders (self.src + "/${self.mainFile}")
      else readFile (self.src + "/${self.mainFile}"));
 in
 lib.getAttrs


### PR DESCRIPTION
Nix blocked an execution of a twist configuration due to IFD, so this may be necessary.

There is at least one location where an IFD is involved. The list of built-in Emacs libraries is an IFD, so it will be necessary to generate the data beforehand.