### PR TITLE
fix: Allow non-list :make values

### DIFF
--- a/pkgs/emacs/data/inventory/elpa.nix
+++ b/pkgs/emacs/data/inventory/elpa.nix
@@ -107,7 +107,7 @@ let
         # There are not so many packages that have :make attribute.
         # Only in GNU, and not in non-GNU.
         lib.optionalString (entry ? make) ''
-          make ${lib.escapeShellArgs entry.make}
+          make ${lib.escapeShellArgs (toList entry.make)}
         '';
     }
     //


### PR DESCRIPTION
This value can take a string or a list of strings. org-tranclusion package now has a string value.