### PR TITLE
feat: Add wantExtraOutputs option

### DIFF
--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -6,6 +6,7 @@
 , lispFiles
 , meta
 , nativeCompileAhead
+, wantExtraOutputs
 , elispInputs
 , ...
 } @ attrs:
@@ -47,9 +48,9 @@ stdenv.mkDerivation {
 
   outputs =
     [ "out" ]
-    ++ lib.optional canProduceInfo "info";
+    ++ lib.optional (wantExtraOutputs && canProduceInfo) "info";
 
-  buildInputs = [ emacs texinfo gnumake ];
+  buildInputs = [ emacs gnumake ] ++ lib.optional wantExtraOutputs "texinfo";
   # nativeBuildInputs = lib.optional nativeComp gcc;
 
   # If the repository contains a Makefile, configurePhase can be problematic, so

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -11,7 +11,8 @@
 , addSystemPackages ? true
 , inputOverrides ? { }
 , nativeCompileAheadDefault ? true
-, extraOutputsToInstall ? [ "info" ]
+, wantExtraOutputs ? true
+, extraOutputsToInstall ? if wantExtraOutputs then [ "info" ] else [ ]
 }:
 let
   inherit (builtins) readFile attrNames attrValues concatLists isFunction
@@ -108,6 +109,7 @@ lib.makeScope pkgs.newScope (self:
             ({
               nativeCompileAhead = nativeCompileAheadDefault;
               elispInputs = lib.attrVals allDependencies.${ename} eself;
+              inherit wantExtraOutputs;
             } // attrs))
         packageInputs);
 


### PR DESCRIPTION
This option allows skipping the build phase for extra outputs (info for now) globally and also omitting its build dependencies. It aims at faster execution on CI for Emacs Lisp packages.