### PR TITLE
A complete rewrite of README

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,36 +1,42 @@
-* Emacs Twist for Nix
-[[https://github.com/akirak/emacs-twist/actions/workflows/test.yml][file:https://github.com/akirak/emacs-twist/actions/workflows/test.yml/badge.svg]]
+* Twist Nix Library
+[[https://github.com/emacs-twist/twist.nix/actions/workflows/test.yml][https://github.com/emacs-twist/twist.nix/actions/workflows/test.yml/badge.svg]]
 
-Emacs Twist is an alternative Emacs Lisp build machinery for Nix.
+Twist.nix is a Nix library for building Emacs configurations with packages.
+It is an infrastructure for configuration and package development.
 
-The goal of this project is to support the following two use cases:
+It is the integral component of [[https://github.com/emacs-twist][emacs-twist]] project.
+The goal of the project is to provide an alternative Emacs ecosystem that uses Nix.
+It is experimental, but also aims to be useful.
 
-- Let people manage their Emacs configurations using Nix in a reproducible way.
-- Help with testing of Emacs Lisp packages that have difficult dependencies, such as dynamic modules and Emacs Lisp packages that are not on any package registry.
+There are several other components under development.
+See the following table for comparison with corresponding to options:
 
-While those use cases are already possible with the standard Emacs infrastructure of Nixpkgs, it was difficult for its users to contribute to packages they are using, compared to [[https://github.com/raxod502/straight.el][straight.el]].
-It is basically a Nix expression generator for packages on ELPA and MELPA, and it assumed that users always want latest packages.
-It was a tedious process to add manual packages or temporarily override sources.
+| Component             | Description           | An alternative to       |
+|-----------------------+-----------------------+-------------------------|
+| twist.nix (this repo) | Build machinery       | [[https://github.com/melpa/package-build/][package-build]]           |
+| [[https://github.com/emacs-twist/twist.el][twist.el]]              | Emacs package manager | [[https://github.com/raxod502/straight.el][straight.el]], [[https://github.com/emacscollective/borg][borg]], etc. |
+| [[https://github.com/emacs-twist/nomake][nomake]]                | Package development   | [[https://github.com/cask/cask][cask]]                    |
 
-The goal of this project is to create a Nix machinery that builds packages from sources.
-It should let the user have full control of package sources.
-Builds are pure when all packages are locked.
+Twist.nix is also an alternative to [[https://nixos.org/manual/nixos/stable/index.html#module-services-emacs][the Emacs infrastructure]] for NixOS.
+Twist.nix depends on Nix utility libraries but does not depend on the standard Emacs wrapper itself in Nixpkgs.
+The difference between twist and the standard wrapper is that twist is capable of building packages from upstream source repositories.
+On the other contrary, the standard wrapper fetches pre-built package archives for most packages, which means it indirectly depends on package-build for MELPA packages.
+With twist, it is easier to lock and update individual packages, because package versions are tracked in flake.lock.
+Twist.el, the package management frontend for Twist, should provide an experience on par with that of straight.el.
 
-It is still an alpha version, so there may be breaking changes.
+Twist can discover packages from the following package databases:
 
-Note that this framework is not compatible with [[https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/emacs/generic.nix][the Emacs infrastructure]] of Nixpkgs.
-This repository provides the core library, and it should be stable.
-I don't want to constantly follow updates in the Nixpkgs and [[https://github.com/nix-community/emacs-overlay][emacs-overlay]].
-They are great projects, but this project does not reuse the infrastructure.
-An entire infrastructure was written from scratch, and this would allow keeping each configuration explicit and predictable.
-No package workarounds are turned on by default, nor will I include such things in this repository.
+- [[https://melpa.org/][MELPA]] packages (built from sources)
+- ELPA external packages (built from sources, only tarballs)
+- ELPA core packages
+- ELPA archives (GNU, non-GNU, and MELPA)
+- [[https://github.com/emacsmirror/][EmacsMirror]]
 
-Nonetheless, it would be possible to provide workarounds as an overlay from a separate repository.
-If this project turns out to be viable, I will do that.
-** Related projects
-[[https://github.com/akirak/twist.el][Twist.el]] is a work-in-progress Emacs frontend to Twist.
-It is just a little fancy wrapper, and its use is optional.
-You can build a configuration without twist.el, and a configuration built with Twist doesn't require Twist.el to run.
-** Examples
-- I am preparing [[https://github.com/akirak/emacs-twist-examples][a repository of configuration examples]].
-- The author's [[https://github.com/akirak/nix-config][nix-config]] repository uses Twist.
+To add custom packages to your configuration, you only have to define MELPA recipes.
+It can already build configurations with hundreds of packages.
+See [[https://github.com/emacs-twist/examples][examples]] for example configurations.
+** Documentation
+The user manual is currently a work in progress.
+** Credits
+Twist is a Nix re-implementation of [[https://github.com/melpa/package-build][package-build]] and replicates its build logic.
+It is also heavily influenced by the Emacs wrapper in [[https://github.com/NixOS/nixpkgs/][nixpkgs]], though twist was written from scratch and different in implementation.


### PR DESCRIPTION
There were duplicates, so I have rewritten it from scratch. This is the first update after migration to emacs-twist org.