### PR TITLE
fix: Allow packages without autoloads

### DIFF
--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -69,7 +69,7 @@ runCommandLocal "emacs"
   siteStartExtra = ''
     (when init-file-user
       ${lib.concatMapStrings (pkg: ''
-          (load "${pkg}/share/emacs/site-lisp/${pkg.ename}-autoloads.el" nil t)
+          (load "${pkg}/share/emacs/site-lisp/${pkg.ename}-autoloads.el" t t)
       '') elispInputs
     })
   '';


### PR DESCRIPTION
There may be packages without autoload annotations, and *-autoloads.el are not generated for those packages. Thus NOERROR should be set to non-nil.