### PR TITLE
Fix discovery of *-pkg.el

### DIFF
--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -19,11 +19,17 @@ let
     attrNames
     (filter (filename: baseNameOf filename == ename + "-pkg.el"))
   ];
-  pkgFile = head pkgFiles;
-  hasPkgFile = length pkgFiles != 0;
+  pkgFile =
+    if length pkgFiles != 0
+    then self.src + "/${head pkgFiles}"
+    else self.src + "/${ename}-pkg.el";
+  #  OPTIMIZE: Reduce filesystem access
+  hasPkgFile =
+    length pkgFiles != 0
+    || pathExists pkgFile;
   packageDesc =
     if hasPkgFile
-    then lib.parsePkg (readFile (self.src + "/${pkgFile}"))
+    then lib.parsePkg (readFile pkgFile)
     else { };
 
   # builtins.readFile fails when the source file contains control characters.

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -3,27 +3,27 @@
     "elisp-helpers": {
       "flake": false,
       "locked": {
-        "lastModified": 1641996288,
-        "narHash": "sha256-0Fz5COcAvNc7Lfmwg+1LcmDiGJivRpHdAFx0SCpjixk=",
-        "owner": "akirak",
-        "repo": "nix-elisp-helpers",
-        "rev": "ec7eaf0f1af9eda3f34d434a6ab4b852629289f4",
+        "lastModified": 1644084222,
+        "narHash": "sha256-Z7K0UkMvjZ+rwzhE2smK5GCl4LkrmY97MKkpay23yDo=",
+        "owner": "emacs-twist",
+        "repo": "elisp-helpers",
+        "rev": "7e295072ec385d0ef7e46efca259d9276542cd6f",
         "type": "github"
       },
       "original": {
-        "owner": "akirak",
-        "repo": "nix-elisp-helpers",
+        "owner": "emacs-twist",
+        "repo": "elisp-helpers",
         "type": "github"
       }
     },
     "emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1640165367,
-        "narHash": "sha256-8MLkCwh9UytjaBgADBU4p4gi0xWz6+RU3GzPJCUbE00=",
+        "lastModified": 1647225971,
+        "narHash": "sha256-qztSaK0lN/QzkqON9E2v+agmf7SU/a+xz2z2xW8VE5Y=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "141bf182da0043c9273b7885e687cfea7f6268b0",
+        "rev": "faab1b20028d11b9f35beacba4b2b278ac0cdab3",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "emacs-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1637854310,
-        "narHash": "sha256-oYwxv+rb5fkxraAle2OMTO6dfIh7yvT3XwXK8IFYUvM=",
+        "lastModified": 1646642800,
+        "narHash": "sha256-u7sABXdhcYAC4k1szBr/xD0zZpRA4u/ZsZ8drWze02Y=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "6ac997af7076d654521870c3a3caabdcc5c37399",
+        "rev": "4de9c1b1b213a37f6b00a0debb2167398015ac3c",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     "epkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1640100785,
-        "narHash": "sha256-aa6qrZQkdAfF7mwz2fIE0oeAaxxQwwVVQmfn7VlSaNY=",
+        "lastModified": 1646670688,
+        "narHash": "sha256-tWbguwt0fb03kehnjfAgT83mxwwhObn0++FuMaEkpPI=",
         "owner": "emacsmirror",
         "repo": "epkgs",
-        "rev": "2a0e752d15198c8939f32f2254afce068bd914b8",
+        "rev": "2d678bf31df3997840c2ef9ee56453caf25c342f",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
     "gnu-elpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1638398219,
-        "narHash": "sha256-+HnJvfrWq6X8K1Uiuuqko45y9kaaWf0dyOs83ViqM2s=",
+        "lastModified": 1647126385,
+        "narHash": "sha256-qzr58b8NTyRnIUQOJbjSrAXzea+dOB5fUHkeeTOLriE=",
         "ref": "main",
-        "rev": "b023942fd434a19c664f84b1a02a81808628dd9e",
-        "revCount": 305,
+        "rev": "80983badda59872df3296bfbb652b132d794a8d6",
+        "revCount": 348,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/elpa.git"
       },
@@ -115,11 +115,11 @@
     "melpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1641923182,
-        "narHash": "sha256-+YKIBsq2EF4lvsI3+x9eL59ORzeI4JXZUOEGfM8XCaY=",
+        "lastModified": 1647200947,
+        "narHash": "sha256-/4NbekHPhy43W+FZ+fgJgl+llaSCJ0Hbvwx1+OoAuX4=",
         "owner": "melpa",
         "repo": "melpa",
-        "rev": "b46e83f2ea2c4df1ef343c79c7e249605c9639b3",
+        "rev": "a60a6643b6d8a5691d48b47c31eb560e0f793d26",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1640139330,
-        "narHash": "sha256-Nkp3wUOGwtoQ7EH28RLVJ7EqB/e0TU7VcsM7GLy+SdY=",
+        "lastModified": 1646939531,
+        "narHash": "sha256-bxOjVqcsccCNm+jSmEh/bm0tqfE3SdjwS+p+FZja3ho=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81cef6b70fb5d5cdba5a0fef3f714c2dadaf0d6d",
+        "rev": "fcd48a5a0693f016a5c370460d0c2a8243b882dc",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     "nongnu": {
       "flake": false,
       "locked": {
-        "lastModified": 1641871990,
-        "narHash": "sha256-duudVw6KV0M41y+CzFEbjvWn5RUJrV8QpUG/Yug6fno=",
+        "lastModified": 1646525328,
+        "narHash": "sha256-f/K4Tj6BtoVERpNXPB0i4PgCrqp/H4Jel+0WPE9MWBA=",
         "ref": "main",
-        "rev": "f9635ef1a6c9b6111c133828a7d73e9ff1bc9e48",
-        "revCount": 155,
+        "rev": "a9b1988f9c7714fdad3bc4d10092b308d658936d",
+        "revCount": 186,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/nongnu.git"
       },
@@ -180,16 +180,16 @@
         "fromElisp": "fromElisp"
       },
       "locked": {
-        "lastModified": 1642002021,
-        "narHash": "sha256-wuVtjO2ne+lDtsjrUemfRLd840YJla+tDIX+yf8EaaQ=",
-        "owner": "akirak",
-        "repo": "emacs-twist",
-        "rev": "34cff2f0c14dbe675e027af89dd7644c31a48c7a",
+        "lastModified": 1647011628,
+        "narHash": "sha256-vq8sazibnJfqhhR3f/aaokvdNGIS1soWL9enqD8l+tU=",
+        "owner": "emacs-twist",
+        "repo": "twist.nix",
+        "rev": "e1057ddef91d9248cb6a5f209620cfaf01cc1cf0",
         "type": "github"
       },
       "original": {
-        "owner": "akirak",
-        "repo": "emacs-twist",
+        "owner": "emacs-twist",
+        "repo": "twist.nix",
         "type": "github"
       }
     }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -5,9 +5,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   inputs.twist = {
-    url = "github:akirak/emacs-twist";
-    inputs.nixpkgs.follows = "nixpkgs";
-    inputs.flake-utils.follows = "flake-utils";
+    url = "github:emacs-twist/twist.nix";
   };
 
   inputs.melpa = {

--- a/test/lock/archive.lock
+++ b/test/lock/archive.lock
@@ -1,9 +1,9 @@
 {
   "bbdb": {
     "archive": {
-      "narHash": "sha256-nldTaqGYqmeQlzgB2vbLADqkx1V/ZfR8ERQfcikg/kk=",
+      "narHash": "sha256-Rm2emSb8aahT5aPdMwhDXnpMRV1JZyUMWBEohXDYpkM=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/bbdb-3.2.tar"
+      "url": "https://elpa.gnu.org/packages/bbdb-3.2.1.tar"
     },
     "inventory": {
       "type": "archive",
@@ -13,7 +13,7 @@
       "cl-lib": "0.5",
       "emacs": "24"
     },
-    "version": "3.2"
+    "version": "3.2.1"
   },
   "ivy": {
     "archive": {

--- a/test/lock/flake.lock
+++ b/test/lock/flake.lock
@@ -80,6 +80,22 @@
         "type": "github"
       }
     },
+    "forge": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646939848,
+        "narHash": "sha256-zvbhwgcaFC3yVfC7kXT1wZKOBaib6gcMnJk0MhvYijQ=",
+        "owner": "magit",
+        "repo": "forge",
+        "rev": "bc99603b5a0cd5b3a5f209772b7f818d205b8a3f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "magit",
+        "repo": "forge",
+        "type": "github"
+      }
+    },
     "git-commit": {
       "flake": false,
       "locked": {
@@ -167,6 +183,7 @@
         "consult": "consult",
         "dash": "dash",
         "doom-themes": "doom-themes",
+        "forge": "forge",
         "git-commit": "git-commit",
         "magit": "magit",
         "magit-section": "magit-section",
@@ -218,15 +235,15 @@
       "locked": {
         "lastModified": 1616545491,
         "narHash": "sha256-Lrp9ooVtDQWUE0/xEjfdJmE7tA7WJyJCbQhIJdeIkEQ=",
-        "owner": "emacsmirror",
-        "repo": "undo-tree",
+        "ref": "master",
         "rev": "2bf5e230f1d11df7bbd9d8c722749e34482bc458",
-        "type": "github"
+        "revCount": 201,
+        "type": "git",
+        "url": "https://gitlab.com/tsc25/undo-tree"
       },
       "original": {
-        "owner": "emacsmirror",
-        "repo": "undo-tree",
-        "type": "github"
+        "type": "git",
+        "url": "https://gitlab.com/tsc25/undo-tree"
       }
     },
     "use-package": {

--- a/test/lock/flake.nix
+++ b/test/lock/flake.nix
@@ -32,6 +32,12 @@
       repo = "themes";
       type = "github";
     };
+    forge = {
+      flake = false;
+      owner = "magit";
+      repo = "forge";
+      type = "github";
+    };
     git-commit = {
       flake = false;
       owner = "magit";
@@ -76,9 +82,8 @@
     };
     undo-tree = {
       flake = false;
-      owner = "emacsmirror";
-      repo = "undo-tree";
-      type = "github";
+      type = "git";
+      url = "https://gitlab.com/tsc25/undo-tree";
     };
     use-package = {
       flake = false;


### PR DESCRIPTION
You need to check existence of *-pkg.el in the root of the repository, even if the file is not implied in :files spec. An example of this case is forge.el. I have experienced several corner cases around packaging in magit org.