### PR TITLE
Add an option to force ignoring the package description file

### DIFF
--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -25,8 +25,9 @@ let
     else self.src + "/${ename}-pkg.el";
   #  OPTIMIZE: Reduce filesystem access
   hasPkgFile =
-    length pkgFiles != 0
-    || pathExists pkgFile;
+    ! (self.ignorePkgFile or false)
+    && (length pkgFiles != 0
+    || pathExists pkgFile);
   packageDesc =
     if hasPkgFile
     then lib.parsePkg (readFile pkgFile)

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -46,7 +46,7 @@
     { flake-utils
     , nixpkgs
     , emacs-ci
-    # , emacs-unstable
+      # , emacs-unstable
     , ...
     } @ inputs:
     flake-utils.lib.eachDefaultSystem (system:
@@ -106,6 +106,12 @@
               "bbdb-vm.el"
               "bbdb-vm-aux.el"
             ];
+          };
+          # google-translate currently contains an invalid pkg file, but it may
+          # be fixed later. See
+          # https://github.com/atykhonov/google-translate/pull/148
+          google-translate = _: _: {
+            ignorePkgFile = true;
           };
         };
       };

--- a/test/init.el
+++ b/test/init.el
@@ -54,3 +54,6 @@
 (use-package bbdb
   :pin gnu
   :ensure t)
+
+(use-package google-translate
+  :ensure t)


### PR DESCRIPTION
This is now necessary, since twist always respects *-pkg.el if it exists (#30).