### PR TITLE
Update tests, use pinned nixpkgs for testing

### DIFF
--- a/test/flake.lock
+++ b/test/flake.lock
@@ -35,11 +35,11 @@
     "emacs-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1646642800,
-        "narHash": "sha256-u7sABXdhcYAC4k1szBr/xD0zZpRA4u/ZsZ8drWze02Y=",
+        "lastModified": 1649081576,
+        "narHash": "sha256-jTPTcKqdqMlgL9LWgz9S/8uRwpwpA4W6koxY+9n7Y8w=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "4de9c1b1b213a37f6b00a0debb2167398015ac3c",
+        "rev": "0cb9368d14ba83f2fc4dfeb85a70f9eb64986fba",
         "type": "github"
       },
       "original": {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,7 +1,6 @@
 {
   description = "";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   inputs.twist = {
@@ -44,7 +43,6 @@
 
   outputs =
     { flake-utils
-    , nixpkgs
     , emacs-ci
       # , emacs-unstable
     , ...
@@ -52,6 +50,9 @@
     flake-utils.lib.eachDefaultSystem (system:
     let
       inherit (builtins) filter match elem;
+
+      # Access niv sources of nix-emacs-ci
+      inherit (import (inputs.emacs-ci + "/nix/sources.nix")) nixpkgs;
 
       pkgs = import nixpkgs {
         inherit system;

--- a/test/lock/archive.lock
+++ b/test/lock/archive.lock
@@ -1,9 +1,9 @@
 {
   "bbdb": {
     "archive": {
-      "narHash": "sha256-Rm2emSb8aahT5aPdMwhDXnpMRV1JZyUMWBEohXDYpkM=",
+      "narHash": "sha256-RpkvwNk/f5yZpPLk6rxAc5UMiQH7IdRXqNKE/O26Hf8=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/bbdb-3.2.1.tar"
+      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.1.tar"
     },
     "inventory": {
       "type": "archive",
@@ -13,7 +13,7 @@
       "cl-lib": "0.5",
       "emacs": "24"
     },
-    "version": "3.2.1"
+    "version": "3.2.2.1"
   },
   "ivy": {
     "archive": {


### PR DESCRIPTION
When one of the ELPA core dependencies is bumped, the build is broken, so you have to update archive.lock.

The snapshot version of emacs-ci has been updated, so the lock file for testing should be updated as well.