### PR TITLE
Update the link to the author's configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ Twist can discover and build packages from the following sources:
 To add custom packages to your configuration, you only have to define MELPA recipes and commit them to your repository.
 It can already build configurations with a few hundreds of packages from various registries (see [[https://github.com/emacs-twist/examples][examples]]).
 ** Status
-- Functionalities: *Good*. The author builds his own [[https://github.com/akirak/nix-config][config]] with twist, and the config is already almost as capable as the previous version which used straight.el. Additionally, [[https://github.com/emacs-twist/nomake][NoMake]] is used in some packages. The basic use cases of twist.nix are covered.
+- Functionalities: *Good*. The author builds his own [[https://git.sr.ht/~akirak/nix-config][config]] with twist, and the config is already almost as capable as the previous version which used straight.el. Additionally, [[https://github.com/emacs-twist/nomake][NoMake]] is used in some packages. The basic use cases of twist.nix are covered.
 - API: *Unstable*. It is mostly stable, but options may undergo changes in the future.
 - Documentation: *Poor*. The author wants to work on his own problems first, and he is not motivated enough to work on the documentation. All the information is currently kept in his mind.
 


### PR DESCRIPTION
Recently, re-development on my configuration repository has been too active. GitHub shows activities on the repository, but I don't want to show it, because I am actually not contributing to projects used by other people. I consider it noisy. Perhaps it looks like cheating.

However, I don't like the idea of making the repository private either. I want to access my config repository from anywhere. Thus I have decided to migrate the configuration repository to [sourcehut](https://sr.ht/). Most of my other repositories will be remain on GitHub, to welcome feedback.