### PR TITLE
Provide update & lock commands as flake apps, not packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,11 +79,11 @@ jobs:
 
     - name: Lock the ELPA packages
       working-directory: test
-      run: nix run .#admin.update --impure
+      run: nix run .#update --impure
 
     - name: Generate the lock file for MELPA packages
       working-directory: test
-      run: nix run .#admin.lock --impure
+      run: nix run .#lock --impure
 
     - name: The lock file exists
       working-directory: test

--- a/doc/flake.nix
+++ b/doc/flake.nix
@@ -7,47 +7,46 @@
     flake = false;
   };
 
-  outputs =
-    { nixpkgs
-    , flake-utils
-    , emacs-ci
-    , ...
-    }:
-    flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [
-          (import (emacs-ci.outPath + "/overlay.nix"))
-        ];
-      };
-    in
-    rec  {
-      # Run this app at the repository root to update documentation in the
-      # doc directory.
-      apps.generate-info = flake-utils.lib.mkApp {
-        drv = pkgs.writeShellApplication {
-          name = "generate-info";
-          runtimeInputs = with pkgs; [
-            emacs-snapshot
-            texinfo
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    emacs-ci,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (import (emacs-ci.outPath + "/overlay.nix"))
           ];
-          text = ''
-            basename=emacs-twist
-            emacs -Q --batch -l ox-texinfo \
-              --eval "(progn
-                        (find-file \"$basename.org\")
-                        (org-texinfo-export-to-texinfo))"
-
-            shopt -s nullglob
-            for t in *.texi *.texinfo
-            do
-              makeinfo --no-split "$t" -o "''${t%%.*}.info"
-            done
-          '';
         };
-      };
-      defaultApp = apps.generate-info;
-    }
+      in rec {
+        # Run this app at the repository root to update documentation in the
+        # doc directory.
+        apps.generate-info = flake-utils.lib.mkApp {
+          drv = pkgs.writeShellApplication {
+            name = "generate-info";
+            runtimeInputs = with pkgs; [
+              emacs-snapshot
+              texinfo
+            ];
+            text = ''
+              basename=emacs-twist
+              emacs -Q --batch -l ox-texinfo \
+                --eval "(progn
+                          (find-file \"$basename.org\")
+                          (org-texinfo-export-to-texinfo))"
+
+              shopt -s nullglob
+              for t in *.texi *.texinfo
+              do
+                makeinfo --no-split "$t" -o "''${t%%.*}.info"
+              done
+            '';
+          };
+        };
+        defaultApp = apps.generate-info;
+      }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -10,15 +10,14 @@
     flake = false;
   };
 
-  outputs = { ... } @ inputs:
-    {
-      # lib is experimental at present, so it may be removed in the future.
-      lib = import ./lib inputs;
-      overlay = import ./pkgs inputs;
+  outputs = {...} @ inputs: {
+    # lib is experimental at present, so it may be removed in the future.
+    lib = import ./lib inputs;
+    overlay = import ./pkgs inputs;
 
-      defaultTemplate = {
-        description = "A basic configuration for use-package";
-        path = ./template;
-      };
+    defaultTemplate = {
+      description = "A basic configuration for use-package";
+      path = ./template;
     };
+  };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,14 +1,10 @@
-inputs:
-{ lib
-}:
-let
+inputs: {lib}: let
   fromElisp = import inputs.fromElisp {
-    pkgs = { inherit lib; };
+    pkgs = {inherit lib;};
   };
 
   inherit (builtins) readFile split filter isString;
-in
-{
+in {
   parseSetup = import ../pkgs/build-support/elisp/parseSetup.nix {
     inherit lib fromElisp;
   };
@@ -17,7 +13,11 @@ in
     inherit lib fromElisp;
   };
 
-  emacsBuiltinLibraries = { stdenv, ripgrep, emacs } @ args:
+  emacsBuiltinLibraries = {
+    stdenv,
+    ripgrep,
+    emacs,
+  } @ args:
     lib.pipe (readFile (import ../pkgs/emacs/builtins.nix args)) [
       (split "\n")
       (filter (s: isString s && s != ""))

--- a/pkgs/build-support/default.nix
+++ b/pkgs/build-support/default.nix
@@ -1,102 +1,133 @@
-{ pkgs
-, inputs
-}:
-let
-  inherit (builtins) head attrNames attrValues filter replaceStrings isList length
-    listToAttrs split match elemAt isString readFile baseNameOf;
+{
+  pkgs,
+  inputs,
+}: let
+  inherit
+    (builtins)
+    head
+    attrNames
+    attrValues
+    filter
+    replaceStrings
+    isList
+    length
+    listToAttrs
+    split
+    match
+    elemAt
+    isString
+    readFile
+    baseNameOf
+    ;
 
   inherit (pkgs) lib;
 
   fromElisp = import inputs.fromElisp {
-    pkgs = { inherit lib; };
+    pkgs = {inherit lib;};
   };
 
   elispHelpers = import inputs.elisp-helpers {
-    pkgs = { inherit lib; };
+    pkgs = {inherit lib;};
   };
 
-  packReqEntriesToAttrs = import ./elisp/packReqEntriesToAttrs.nix { inherit lib; };
+  packReqEntriesToAttrs = import ./elisp/packReqEntriesToAttrs.nix {inherit lib;};
 
   gitUrlToAttrs = import ./gitUrlToAttrs.nix;
 
-  parseSubmoduleConfigEntries = s: lib.pipe s [
-    (split "\n")
-    (filter isString)
-    # Exclude entries starting with _
-    (map (match "submodule.([^_][^.]+).url=(.+)"))
-    (filter isList)
-    (map (x: ({
-      name = elemAt x 0;
-      value = gitUrlToAttrs (elemAt x 1);
-    })))
-    listToAttrs
-  ];
+  parseSubmoduleConfigEntries = s:
+    lib.pipe s [
+      (split "\n")
+      (filter isString)
+      # Exclude entries starting with _
+      (map (match "submodule.([^_][^.]+).url=(.+)"))
+      (filter isList)
+      (map (x: {
+        name = elemAt x 0;
+        value = gitUrlToAttrs (elemAt x 1);
+      }))
+      listToAttrs
+    ];
 in
-lib
-  //
-{
-  inherit (elispHelpers)
-    parsePkg
-    parseElpaPackages
-    expandMelpaRecipeFiles
-    flakeRefAttrsFromElpaAttrs
-    parseMelpaRecipe
-    flakeRefAttrsFromMelpaRecipe;
+  lib
+  // {
+    inherit
+      (elispHelpers)
+      parsePkg
+      parseElpaPackages
+      expandMelpaRecipeFiles
+      flakeRefAttrsFromElpaAttrs
+      parseMelpaRecipe
+      flakeRefAttrsFromMelpaRecipe
+      ;
 
-  makeSourceVersion = version: _src: version;
-  toPName = replaceStrings [ "@" ] [ "at" ];
+    makeSourceVersion = version: _src: version;
+    toPName = replaceStrings ["@"] ["at"];
 
-  toNix = import ./toNix.nix { inherit lib; };
+    toNix = import ./toNix.nix {inherit lib;};
 
-  findLicense = spdxId:
-    lib.findFirst
+    findLicense = spdxId:
+      lib.findFirst
       (license: (license ? spdxId && license.spdxId == spdxId))
       null
       (attrValues lib.licenses);
 
-  parseElispHeaders = import ./elisp/parseElispHeaders.nix { inherit lib; };
+    parseElispHeaders = import ./elisp/parseElispHeaders.nix {inherit lib;};
 
-  parsePackageRequireLines = lines:
-    if lines == null
-    then { }
-    else
-      lib.pipe (if isList lines then lib.concatStringsSep " " lines else lines) [
-        fromElisp.fromElisp
-        (xs: if length xs == 0 then [ ] else head xs)
-        packReqEntriesToAttrs
+    parsePackageRequireLines = lines:
+      if lines == null
+      then {}
+      else
+        lib.pipe (
+          if isList lines
+          then lib.concatStringsSep " " lines
+          else lines
+        ) [
+          fromElisp.fromElisp
+          (xs:
+            if length xs == 0
+            then []
+            else head xs)
+          packReqEntriesToAttrs
+        ];
+
+    parseUsePackages = import ./elisp/parseUsePackages.nix {inherit lib fromElisp;};
+
+    /*
+      Transform an attribute set of packageRequires to a list of library names,
+     excluding emacs.
+     */
+    packageRequiresToLibraryNames = packageRequires:
+      lib.pipe packageRequires [
+        attrNames
+        (filter (name: name != "emacs"))
       ];
 
-  parseUsePackages = import ./elisp/parseUsePackages.nix { inherit lib fromElisp; };
+    readGitModulesFile = file:
+      parseSubmoduleConfigEntries
+      (readFile (pkgs.callPackage
+        ({
+          git,
+          runCommandLocal,
+        }:
+          runCommandLocal "gitmodules-output" {} ''
+            ${git}/bin/git --no-pager config --list -f ${file} > $out
+          '')
+        {}));
 
-  /* Transform an attribute set of packageRequires to a list of library names,
-    excluding emacs. */
-  packageRequiresToLibraryNames = packageRequires: lib.pipe packageRequires [
-    attrNames
-    (filter (name: name != "emacs"))
-  ];
+    readFirstBytes = limit: file:
+      readFile (pkgs.callPackage
+        ({runCommandLocal}:
+          runCommandLocal (baseNameOf file) {} ''
+            head -c ${toString limit} ${file} > $out
+          '')
+        {});
 
-  readGitModulesFile = file: parseSubmoduleConfigEntries
-    (readFile (pkgs.callPackage
-      ({ git, runCommandLocal }:
-        runCommandLocal "gitmodules-output" { } ''
-          ${git}/bin/git --no-pager config --list -f ${file} > $out
-        '')
-      { }));
+    # Just a shorthand for overriding a nested attribute.
+    # I am looking for a better syntax for overriding multiple packages.
+    # I would want a kind of recursive updating with recursion limit.
+    # overrideAttrsByPath = import ./overrideAttrsByPath.nix { inherit lib; };
 
-  readFirstBytes = limit: file:
-    readFile (pkgs.callPackage
-      ({ runCommandLocal }:
-        runCommandLocal (baseNameOf file) { } ''
-          head -c ${toString limit} ${file} > $out
-        '')
-      { });
-
-  # Just a shorthand for overriding a nested attribute.
-  # I am looking for a better syntax for overriding multiple packages.
-  # I would want a kind of recursive updating with recursion limit.
-  # overrideAttrsByPath = import ./overrideAttrsByPath.nix { inherit lib; };
-
-  readPackageArchiveContents = import ./elisp/readArchiveContents.nix {
-    inherit lib fromElisp;
-  };
-}
+    readPackageArchiveContents = import ./elisp/readArchiveContents.nix {
+      inherit lib fromElisp;
+    };
+  }

--- a/pkgs/build-support/elisp/collectFromSetup.nix
+++ b/pkgs/build-support/elisp/collectFromSetup.nix
@@ -1,35 +1,38 @@
-{ lib
-}:
-keyword:
-with builtins;
-let
-  go = { data, rest } @ acc: fields:
-    {
-      data = data ++ lib.pipe fields [
+{lib}: keyword:
+with builtins; let
+  go = {
+    data,
+    rest,
+  } @ acc: fields: {
+    data =
+      data
+      ++ lib.pipe fields [
         (map (field:
           if isList field && length field > 0 && head field == keyword
           then tail field
           else null))
         (filter lib.isList)
       ];
-      rest = (lib.pipe fields [
+    rest =
+      (lib.pipe fields [
         (filter isList)
         concatLists
         (filter isList)
-      ]) ++ rest;
-    };
+      ])
+      ++ rest;
+  };
 
-  recurse = { rest, ... } @ acc:
-    if rest == [ ]
-    then removeAttrs acc [ "rest" ]
-    else recurse (go (acc // { rest = [ ]; }) rest);
+  recurse = {rest, ...} @ acc:
+    if rest == []
+    then removeAttrs acc ["rest"]
+    else recurse (go (acc // {rest = [];}) rest);
 in
-blocks:
-lib.pipe blocks [
-  (foldl' go {
-    data = [ ];
-    rest = [ ];
-  })
-  recurse
-  (attrs: attrs.data)
-]
+  blocks:
+    lib.pipe blocks [
+      (foldl' go {
+        data = [];
+        rest = [];
+      })
+      recurse
+      (attrs: attrs.data)
+    ]

--- a/pkgs/build-support/elisp/packReqEntriesToAttrs.nix
+++ b/pkgs/build-support/elisp/packReqEntriesToAttrs.nix
@@ -1,35 +1,36 @@
-/* Processing a list of Package-Requires in Emacs Lisp libraries.
-  <https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html>
-
-  This returns a set of attributes in which the name is a library name and
-  the value is either a required library version or null.
-*/
+/*
+  Processing a list of Package-Requires in Emacs Lisp libraries.
+ <https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html>
+ 
+ This returns a set of attributes in which the name is a library name and
+ the value is either a required library version or null.
+ */
 let
   inherit (builtins) isString isList map head length elemAt listToAttrs;
 in
-{ lib }:
-xs:
-lib.pipe xs [
-  (map (name:
-    if isString name
-    then {
-      inherit name;
-      value = null;
-    }
-    else if isList name
-    then {
-      name = lib.removePrefix ":" (head name);
-      # There can be a plist where no value is provided for the final key,
-      # which should be considered a nil value.
-      #
-      # This is valid in lisp, but there is a missing name, so you have
-      # to check it.
-      value =
-        if (length name < 2) || (elemAt name 1) == [ ]
-        then null
-        else (elemAt name 1);
-    }
-    else throw "Unsupported Package-Requires entry: ${name}"
-  ))
-  listToAttrs
-]
+  {lib}: xs:
+    lib.pipe xs [
+      (map (
+        name:
+          if isString name
+          then {
+            inherit name;
+            value = null;
+          }
+          else if isList name
+          then {
+            name = lib.removePrefix ":" (head name);
+            # There can be a plist where no value is provided for the final key,
+            # which should be considered a nil value.
+            #
+            # This is valid in lisp, but there is a missing name, so you have
+            # to check it.
+            value =
+              if (length name < 2) || (elemAt name 1) == []
+              then null
+              else (elemAt name 1);
+          }
+          else throw "Unsupported Package-Requires entry: ${name}"
+      ))
+      listToAttrs
+    ]

--- a/pkgs/build-support/elisp/parseElispHeaders.nix
+++ b/pkgs/build-support/elisp/parseElispHeaders.nix
@@ -1,6 +1,5 @@
-{ lib }: string:
-with builtins;
-let
+{lib}: string:
+with builtins; let
   # It should contain at least one line.
   lines = filter isString (split "\n" string);
 
@@ -19,25 +18,28 @@ let
 
   headLine = head lines;
 
-  stripMagic = line:
-    let
-      m = match magicHeaderRegex line;
-    in
+  stripMagic = line: let
+    m = match magicHeaderRegex line;
+  in
     if m == null
     then line
     else head m;
 
-  summary =
-    let
-      m = match descriptionRegex headLine;
-    in
+  summary = let
+    m = match descriptionRegex headLine;
+  in
     if m == null
     then null
     else trimRight (stripMagic (head m));
 
-  lines' = lib.pipe (if lib.hasInfix "---" headLine then tail lines else lines) [
-    (takeWhile (s: match ";;;.*" s == null))
-  ];
+  lines' =
+    lib.pipe (
+      if lib.hasInfix "---" headLine
+      then tail lines
+      else lines
+    ) [
+      (takeWhile (s: match ";;;.*" s == null))
+    ];
 
   isHeader = s: match headerRegex s != null;
 
@@ -50,61 +52,65 @@ let
     then null
     else head xs;
 
-  headerContent = key: s: lib.pipe s [
-    (match (makeHeaderRegex key))
-    (lib.mapNullable (m: trim (head m)))
-  ];
+  headerContent = key: s:
+    lib.pipe s [
+      (match (makeHeaderRegex key))
+      (lib.mapNullable (m: trim (head m)))
+    ];
 
-  lookupHeader = key: lib.pipe (findHeader key) [
-    safeHead
-    (lib.mapNullable (headerContent key))
-  ];
+  lookupHeader = key:
+    lib.pipe (findHeader key) [
+      safeHead
+      (lib.mapNullable (headerContent key))
+    ];
 
-  uncommentLine = s: lib.pipe (match ";+[[:space:]]*(.+)" s) [
-    head
-    trim
-  ];
+  uncommentLine = s:
+    lib.pipe (match ";+[[:space:]]*(.+)" s) [
+      head
+      trim
+    ];
 
-  lookupMultiLineHeader = key: pred: lib.pipe (findHeader key) [
-    (xs:
-      if length xs == 0
-      then [ ]
-      else [ (headerContent key (head xs)) ]
-        ++
-        lib.pipe (tail xs)
+  lookupMultiLineHeader = key: pred:
+    lib.pipe (findHeader key) [
+      (xs:
+        if length xs == 0
+        then []
+        else
+          [(headerContent key (head xs))]
+          ++ lib.pipe (tail xs)
           [
             (takeWhile pred)
             (map uncommentLine)
           ])
-    (filter (s: s != ""))
-    (xs:
-      if length xs == 0
-      then null
-      else if length xs == 1
-      then head xs
-      else xs)
-  ];
+      (filter (s: s != ""))
+      (xs:
+        if length xs == 0
+        then null
+        else if length xs == 1
+        then head xs
+        else xs)
+    ];
 
   succeeding = s: isNotHeader s && s != "";
 
   splitKeywords = s:
     if s == ""
-    then [ ]
+    then []
     else filter isString (split "[,[:space:]]+" s);
 in
-lib.filterAttrs (_: v: v != null) ({
-  inherit summary;
+  lib.filterAttrs (_: v: v != null) {
+    inherit summary;
 
-  Version = lookupHeader "Version";
-  Package-Version = lookupHeader "Package-Version";
-  URL = lookupHeader "URL";
-  Homepage = lookupHeader "Homepage";
-  SPDX-License-Identifier = lookupHeader "SPDX-License-Identifier";
-  Keywords = lib.mapNullable (s: splitKeywords (trim s)) (lookupHeader "Keywords");
-  Package-Requires = lookupMultiLineHeader "Package-Requires" succeeding;
-  Author = lookupMultiLineHeader "Author" succeeding;
-  Maintainer = lookupMultiLineHeader "Maintainer" succeeding;
+    Version = lookupHeader "Version";
+    Package-Version = lookupHeader "Package-Version";
+    URL = lookupHeader "URL";
+    Homepage = lookupHeader "Homepage";
+    SPDX-License-Identifier = lookupHeader "SPDX-License-Identifier";
+    Keywords = lib.mapNullable (s: splitKeywords (trim s)) (lookupHeader "Keywords");
+    Package-Requires = lookupMultiLineHeader "Package-Requires" succeeding;
+    Author = lookupMultiLineHeader "Author" succeeding;
+    Maintainer = lookupMultiLineHeader "Maintainer" succeeding;
 
-  # Below is optional
-  # Created
-})
+    # Below is optional
+    # Created
+  }

--- a/pkgs/build-support/elisp/parseSetup.nix
+++ b/pkgs/build-support/elisp/parseSetup.nix
@@ -1,31 +1,31 @@
 # Parse configuration that uses setup.el <https://git.sr.ht/~pkal/setup>
-{ lib
-, fromElisp
-}:
-{ packageKeyword ? ":package"
-, nixpkgsKeyword ? ":nixpkgs"
+{
+  lib,
+  fromElisp,
+}: {
+  packageKeyword ? ":package",
+  nixpkgsKeyword ? ":nixpkgs",
 }:
 with builtins;
-string:
-let
-  setups = lib.pipe (fromElisp.fromElisp string) [
-    (filter (block: head block == "setup"))
-    (map tail)
-  ];
+  string: let
+    setups = lib.pipe (fromElisp.fromElisp string) [
+      (filter (block: head block == "setup"))
+      (map tail)
+    ];
 
-  collect = import ./collectFromSetup.nix { inherit lib; };
-in
-{
-  elispPackages = lib.pipe (collect packageKeyword setups) [
-    lib.concatLists
-    lib.unique
-  ];
-
-  systemPackages =
-    if isString nixpkgsKeyword
-    then lib.pipe (collect nixpkgsKeyword setups) [
+    collect = import ./collectFromSetup.nix {inherit lib;};
+  in {
+    elispPackages = lib.pipe (collect packageKeyword setups) [
       lib.concatLists
       lib.unique
-    ]
-    else [ ];
-}
+    ];
+
+    systemPackages =
+      if isString nixpkgsKeyword
+      then
+        lib.pipe (collect nixpkgsKeyword setups) [
+          lib.concatLists
+          lib.unique
+        ]
+      else [];
+  }

--- a/pkgs/build-support/elisp/parseUsePackages.nix
+++ b/pkgs/build-support/elisp/parseUsePackages.nix
@@ -1,11 +1,8 @@
-{ lib
-, fromElisp
-}:
-{ alwaysEnsure ? false
-}:
-string:
-with builtins;
-let
+{
+  lib,
+  fromElisp,
+}: {alwaysEnsure ? false}: string:
+with builtins; let
   blocks = fromElisp.fromElisp string;
   plistGet = xs: key:
     if length xs == 0
@@ -30,9 +27,9 @@ let
     else tail x;
   toSystemPackages = x:
     if x == null
-    then [ ]
+    then []
     else if isString x
-    then [ x ]
+    then [x]
     else if isList x
     then listToSystemPackages x
     else trace x (throw ":ensure-system-package must be either a list or a string");
@@ -40,8 +37,7 @@ let
     toSystemPackages (plistGet form ":ensure-system-package");
   directPackages = map enameFromUsePackage (filter isEnsured usePackageForms);
   indirectPackages = filter isString (map ensuredPackageName usePackageForms);
-in
-{
+in {
   elispPackages = lib.unique (directPackages ++ indirectPackages);
   elispPackagePins = lib.pipe usePackageForms [
     (map (form: {
@@ -49,7 +45,7 @@ in
       name = enameFromUsePackage form;
       value = findPin form;
     }))
-    (filter ({ value, ... }: value != null))
+    (filter ({value, ...}: value != null))
     listToAttrs
   ];
   systemPackages = lib.concatMap ensuredSystemPackages usePackageForms;

--- a/pkgs/build-support/elisp/readArchiveContents.nix
+++ b/pkgs/build-support/elisp/readArchiveContents.nix
@@ -1,18 +1,18 @@
-{ lib
-, fromElisp
-}:
-prefixUrl:
+{
+  lib,
+  fromElisp,
+}: prefixUrl:
 with builtins;
-lib.pipe (fetchurl (prefixUrl + "archive-contents")) [
-  readFile
-  fromElisp.fromElisp
-  head
-  # I don't understand the exact format of the package archives.
-  # I don't know why the first element is 1, but I'll just drop it.
-  tail
-  (map (xs: {
-    name = head xs;
-    value = tail xs;
-  }))
-  listToAttrs
-]
+  lib.pipe (fetchurl (prefixUrl + "archive-contents")) [
+    readFile
+    fromElisp.fromElisp
+    head
+    # I don't understand the exact format of the package archives.
+    # I don't know why the first element is 1, but I'll just drop it.
+    tail
+    (map (xs: {
+      name = head xs;
+      value = tail xs;
+    }))
+    listToAttrs
+  ]

--- a/pkgs/build-support/elisp/testHeader.nix
+++ b/pkgs/build-support/elisp/testHeader.nix
@@ -1,77 +1,76 @@
-with builtins;
-let
-  pkgs = import <nixpkgs> { };
-  parseElispHeaders = import ./parseElispHeaders.nix { inherit (pkgs) lib; };
+with builtins; let
+  pkgs = import <nixpkgs> {};
+  parseElispHeaders = import ./parseElispHeaders.nix {inherit (pkgs) lib;};
 in
-pkgs.lib.runTests {
-  testBasic = {
-    expr = parseElispHeaders (readFile ./testdata/header-basic.el);
-    expected = {
-      summary = "A basic configuration framework for org mode";
-      Author = "Akira Komamura <akira.komamura@gmail.com>";
-      Version = "0.2.9";
-      Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
-      URL = "https://github.com/akirak/org-starter";
+  pkgs.lib.runTests {
+    testBasic = {
+      expr = parseElispHeaders (readFile ./testdata/header-basic.el);
+      expected = {
+        summary = "A basic configuration framework for org mode";
+        Author = "Akira Komamura <akira.komamura@gmail.com>";
+        Version = "0.2.9";
+        Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
+        URL = "https://github.com/akirak/org-starter";
+      };
     };
-  };
 
-  testLicense = {
-    expr = parseElispHeaders (readFile ./testdata/header-license.el);
-    expected = {
-      summary = "A basic configuration framework for org mode";
-      Author = "Akira Komamura <akira.komamura@gmail.com>";
-      SPDX-License-Identifier = "GPL-3.0-or-later";
+    testLicense = {
+      expr = parseElispHeaders (readFile ./testdata/header-license.el);
+      expected = {
+        summary = "A basic configuration framework for org mode";
+        Author = "Akira Komamura <akira.komamura@gmail.com>";
+        SPDX-License-Identifier = "GPL-3.0-or-later";
+      };
     };
-  };
 
-  testAlmostNone = {
-    expr = parseElispHeaders (readFile ./testdata/header-almost-none.el);
-    expected = {
-      Version = "0.1";
-      Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
+    testAlmostNone = {
+      expr = parseElispHeaders (readFile ./testdata/header-almost-none.el);
+      expected = {
+        Version = "0.1";
+        Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
+      };
     };
-  };
 
-  testMultiLine = {
-    expr = parseElispHeaders (readFile ./testdata/header-multi-line.el);
-    expected = {
-      summary = "A basic configuration framework for org mode";
-      Version = "0.2.9";
-      Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
-      Author = [
-        "Akira Komamura <akira.komamura@gmail.com>"
-        "Someone from somewhere else <someone@galaxy.space>"
-      ];
-      Maintainer = [
-        "My Son <myson@earth.net>"
-        "Your Grandpa <yourgrandpa@earth.net>"
-      ];
-      URL = "https://github.com/akirak/org-starter";
+    testMultiLine = {
+      expr = parseElispHeaders (readFile ./testdata/header-multi-line.el);
+      expected = {
+        summary = "A basic configuration framework for org mode";
+        Version = "0.2.9";
+        Package-Requires = "((emacs \"25.1\") (dash \"2.18\"))";
+        Author = [
+          "Akira Komamura <akira.komamura@gmail.com>"
+          "Someone from somewhere else <someone@galaxy.space>"
+        ];
+        Maintainer = [
+          "My Son <myson@earth.net>"
+          "Your Grandpa <yourgrandpa@earth.net>"
+        ];
+        URL = "https://github.com/akirak/org-starter";
+      };
     };
-  };
 
-  testNoLexical = {
-    expr = parseElispHeaders (readFile ./testdata/header-no-lexical.el);
-    expected = {
-      summary = "A basic configuration framework for org mode";
-      Author = "Akira Komamura <akira.komamura@gmail.com>";
+    testNoLexical = {
+      expr = parseElispHeaders (readFile ./testdata/header-no-lexical.el);
+      expected = {
+        summary = "A basic configuration framework for org mode";
+        Author = "Akira Komamura <akira.komamura@gmail.com>";
+      };
     };
-  };
 
-  testAsteriskDesc = {
-    expr = parseElispHeaders (readFile ./testdata/header-asterisk-desc.el);
-    expected = {
-      summary = "A library that contains *asterisk* in its description";
-      Author = "Akira Komamura <akira.komamura@gmail.com>";
+    testAsteriskDesc = {
+      expr = parseElispHeaders (readFile ./testdata/header-asterisk-desc.el);
+      expected = {
+        summary = "A library that contains *asterisk* in its description";
+        Author = "Akira Komamura <akira.komamura@gmail.com>";
+      };
     };
-  };
 
-  testMiniEdit = {
-    expr = parseElispHeaders (readFile ./testdata/header-miniedit.el);
-    expected = {
-      summary = "Enhanced editing for minibuffer fields.";
-      Version = "2.0";
-      # Author(s) is currently ignored, as it's not a conventional header
+    testMiniEdit = {
+      expr = parseElispHeaders (readFile ./testdata/header-miniedit.el);
+      expected = {
+        summary = "Enhanced editing for minibuffer fields.";
+        Version = "2.0";
+        # Author(s) is currently ignored, as it's not a conventional header
+      };
     };
-  };
-}
+  }

--- a/pkgs/build-support/elisp/testParseSetup.nix
+++ b/pkgs/build-support/elisp/testParseSetup.nix
@@ -1,78 +1,73 @@
-with builtins;
-let
-  pkgs = import <nixpkgs> { };
+with builtins; let
+  pkgs = import <nixpkgs> {};
   fromElisp = import (fetchTree (fromJSON (readFile ../../../flake.lock)).nodes.fromElisp.locked) {
     inherit pkgs;
   };
   parseSetup = import ./parseSetup.nix {
     inherit (pkgs) lib;
     inherit fromElisp;
-  } { };
+  } {};
 in
-pkgs.lib.runTests {
-  testFlat = {
+  pkgs.lib.runTests {
+    testFlat = {
+      expr = parseSetup ''
 
-    expr = parseSetup ''
+        (setup (:package dash))
 
-      (setup (:package dash))
+        (setup magit
+          (:package magit)
+          (:nixpkgs git))
 
-      (setup magit
-        (:package magit)
-        (:nixpkgs git))
+        (setup (:package aftermath afterlife))
 
-      (setup (:package aftermath afterlife))
+      '';
 
-    '';
-
-    expected = {
-      elispPackages = [
-        "dash"
-        "magit"
-        "aftermath"
-        "afterlife"
-      ];
-      systemPackages = [
-        "git"
-      ];
+      expected = {
+        elispPackages = [
+          "dash"
+          "magit"
+          "aftermath"
+          "afterlife"
+        ];
+        systemPackages = [
+          "git"
+        ];
+      };
     };
 
-  };
+    testNested = {
+      expr = parseSetup ''
 
-  testNested = {
+        (setup (:package university)
+          (:load-after good-scores
+            (:package master-degree)
+          (:load-after master-degree
+            (:load-after job-experience
+              (:package work-visa))
+            (:load-after ph-d
+              (:package work-visa)))))
 
-    expr = parseSetup ''
+        (setup t
+          (:load-after million-dollars
+            (:package retirement)))
 
-      (setup (:package university)
-        (:load-after good-scores
-          (:package master-degree)
-        (:load-after master-degree
-          (:load-after job-experience
-            (:package work-visa))
-          (:load-after ph-d
-            (:package work-visa)))))
+        (setup (:package china)
+          (:load-after car
+            (:load-after house
+              (:package marriage))))
 
-      (setup t
-        (:load-after million-dollars
-          (:package retirement)))
+      '';
 
-      (setup (:package china)
-        (:load-after car
-          (:load-after house
-            (:package marriage))))
-
-    '';
-
-    expected = {
-      elispPackages = [
-        "university"
-        "china"
-        "retirement"
-        "master-degree"
-        "marriage"
-        "work-visa"
-      ];
-      systemPackages = [ ];
+      expected = {
+        elispPackages = [
+          "university"
+          "china"
+          "retirement"
+          "master-degree"
+          "marriage"
+          "work-visa"
+        ];
+        systemPackages = [];
+      };
     };
-
-  };
-}
+  }

--- a/pkgs/build-support/elisp/testUsePackage.nix
+++ b/pkgs/build-support/elisp/testUsePackage.nix
@@ -1,6 +1,5 @@
-with builtins;
-let
-  pkgs = import <nixpkgs> { };
+with builtins; let
+  pkgs = import <nixpkgs> {};
   fromElisp = import (fetchTree (fromJSON (readFile ../../../flake.lock)).nodes.fromElisp.locked) {
     inherit pkgs;
   };
@@ -9,45 +8,45 @@ let
     inherit fromElisp;
   };
 
-  validateConfig = import ./validateConfig.nix { inherit (pkgs) lib; };
+  validateConfig = import ./validateConfig.nix {inherit (pkgs) lib;};
 in
-pkgs.lib.runTests {
-  testDirect = {
-    expr = validateConfig (parseUsePackages { } ''
-      (use-package hello)
+  pkgs.lib.runTests {
+    testDirect = {
+      expr = validateConfig (parseUsePackages {} ''
+        (use-package hello)
 
-      (use-package bye :ensure t)
-    '');
-    expected = {
-      elispPackages = [ "bye" ];
-      elispPackagePins = { };
-      systemPackages = [ ];
-    };
-  };
-
-  testEnsureAnother = {
-    expr = parseUsePackages { } ''
-      (use-package zaijian :ensure bye)
-    '';
-    expected = {
-      elispPackages = [ "bye" ];
-      elispPackagePins = { };
-      systemPackages = [ ];
-    };
-  };
-
-  testPin = {
-    expr = parseUsePackages { } ''
-      (use-package hello
-        :ensure t
-        :pin american)
-    '';
-    expected = {
-      elispPackages = [ "hello" ];
-      elispPackagePins = {
-        hello = "american";
+        (use-package bye :ensure t)
+      '');
+      expected = {
+        elispPackages = ["bye"];
+        elispPackagePins = {};
+        systemPackages = [];
       };
-      systemPackages = [ ];
     };
-  };
-}
+
+    testEnsureAnother = {
+      expr = parseUsePackages {} ''
+        (use-package zaijian :ensure bye)
+      '';
+      expected = {
+        elispPackages = ["bye"];
+        elispPackagePins = {};
+        systemPackages = [];
+      };
+    };
+
+    testPin = {
+      expr = parseUsePackages {} ''
+        (use-package hello
+          :ensure t
+          :pin american)
+      '';
+      expected = {
+        elispPackages = ["hello"];
+        elispPackagePins = {
+          hello = "american";
+        };
+        systemPackages = [];
+      };
+    };
+  }

--- a/pkgs/build-support/elisp/validateConfig.nix
+++ b/pkgs/build-support/elisp/validateConfig.nix
@@ -1,28 +1,32 @@
 # Validate the output of an init parser
-{ lib }:
-with builtins;
-let
-  headOrNull = xs: if length xs == 0 then null else head xs;
+{lib}:
+with builtins; let
+  headOrNull = xs:
+    if length xs == 0
+    then null
+    else head xs;
 
   validatePackageList = value:
     if ! isList value
     then "A package list must be a list: ${toJSON value}"
-    else lib.pipe value [
-      (filter (v: ! isString v))
-      (map (v: "Package name must be a string: ${toJSON v}"))
-      headOrNull
-    ];
+    else
+      lib.pipe value [
+        (filter (v: ! isString v))
+        (map (v: "Package name must be a string: ${toJSON v}"))
+        headOrNull
+      ];
 
   validatePackagePins = value:
     if ! isAttrs value
     then "Package pins must be an attribute set: ${toJSON value}"
-    else lib.pipe value [
-      (lib.filterAttrs (_name: v: ! isString v))
-      (lib.mapAttrsToList (_name: v:
-        "A package pin must have a string value: ${toJSON v}"
-      ))
-      headOrNull
-    ];
+    else
+      lib.pipe value [
+        (lib.filterAttrs (_name: v: ! isString v))
+        (lib.mapAttrsToList (
+          _name: v: "A package pin must have a string value: ${toJSON v}"
+        ))
+        headOrNull
+      ];
 
   checkResultAttr = name: value:
     if name == "elispPackages"
@@ -33,13 +37,17 @@ let
     then validatePackageList value
     else "Unexpected attribute in the result: ${name}";
 in
-output:
-if ! isAttrs output
-then throw "The parser must return attrs"
-else if ! output ? elispPackages
-then throw "elispPackages is required"
-else lib.pipe output [
-  (lib.mapAttrsToList checkResultAttr)
-  headOrNull
-  (r: if r == null then output else throw r)
-]
+  output:
+    if ! isAttrs output
+    then throw "The parser must return attrs"
+    else if ! output ? elispPackages
+    then throw "elispPackages is required"
+    else
+      lib.pipe output [
+        (lib.mapAttrsToList checkResultAttr)
+        headOrNull
+        (r:
+          if r == null
+          then output
+          else throw r)
+      ]

--- a/pkgs/build-support/gitUrlToAttrs.nix
+++ b/pkgs/build-support/gitUrlToAttrs.nix
@@ -1,12 +1,11 @@
 s:
-with builtins;
-let
+with builtins; let
   githubMatch = match "git@github.com:(.+)/(.+)\.git" s;
 in
-if githubMatch != null
-then {
-  type = "github";
-  owner = elemAt githubMatch 0;
-  repo = elemAt githubMatch 1;
-}
-else throw "Git url does not match any pattern: ${s}"
+  if githubMatch != null
+  then {
+    type = "github";
+    owner = elemAt githubMatch 0;
+    repo = elemAt githubMatch 1;
+  }
+  else throw "Git url does not match any pattern: ${s}"

--- a/pkgs/build-support/overrideAttrsByPath.nix
+++ b/pkgs/build-support/overrideAttrsByPath.nix
@@ -1,19 +1,16 @@
 # This function was intended for use inside overrideScope' call but is
 # currently deprecated. This function would slightly reduce a boilerplate,
 # but I am not sure if it is useful.
-{ lib }:
-super: path:
-let
+{lib}: super: path: let
   inherit (builtins) length elemAt;
   n = length path;
   parent = lib.attrByPath (lib.take (n - 1) path) null super;
   prev = lib.attrByPath path null super;
 in
-f:
-lib.setAttrByPath (lib.take (n - 1) path) (
-  parent
-  //
-  {
-    ${elemAt path (n - 1)} = prev.overrideAttrs f;
-  }
-)
+  f:
+    lib.setAttrByPath (lib.take (n - 1) path) (
+      parent
+      // {
+        ${elemAt path (n - 1)} = prev.overrideAttrs f;
+      }
+    )

--- a/pkgs/build-support/testToNix.nix
+++ b/pkgs/build-support/testToNix.nix
@@ -1,30 +1,29 @@
-with builtins;
-let
-  pkgs = import <nixpkgs> { };
+with builtins; let
+  pkgs = import <nixpkgs> {};
 
-  toNix = import ./toNix.nix { inherit (pkgs) lib; };
+  toNix = import ./toNix.nix {inherit (pkgs) lib;};
 in
-pkgs.lib.runTests {
-  testParse = {
-    expr = toNix {
-      description = "description";
-      inputs = {
-        bind-key = {
-          flake = false;
-          owner = "jwiegley";
-          repo = "use-package";
-          type = "github";
+  pkgs.lib.runTests {
+    testParse = {
+      expr = toNix {
+        description = "description";
+        inputs = {
+          bind-key = {
+            flake = false;
+            owner = "jwiegley";
+            repo = "use-package";
+            type = "github";
+          };
+          "bind-key+" = {
+            flake = false;
+            owner = "jwiegley";
+            repo = "use-package";
+            type = "github";
+          };
         };
-        "bind-key+" = {
-          flake = false;
-          owner = "jwiegley";
-          repo = "use-package";
-          type = "github";
-        };
+        outputs = {...}: {};
       };
-      outputs = { ... }: { };
+      expected = ''
+        { description = "description"; inputs = { bind-key = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; "bind-key+" = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; }; outputs = <LAMBDA>; }'';
     };
-    expected = ''
-      { description = "description"; inputs = { bind-key = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; "bind-key+" = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; }; outputs = <LAMBDA>; }'';
-  };
-}
+  }

--- a/pkgs/build-support/toNix.nix
+++ b/pkgs/build-support/toNix.nix
@@ -1,6 +1,7 @@
-/* An incomplete implementation of Nix serialization. */
-{ lib }:
-let
+/*
+ An incomplete implementation of Nix serialization.
+ */
+{lib}: let
   inherit (builtins) isList isAttrs isFunction toJSON concatStringsSep match;
 
   isPrimitive = v: ! (isList v || isAttrs v || isFunction v);
@@ -9,7 +10,7 @@ let
 
   printList = v:
     wrap "[ " " ]"
-      (lib.concatMapStringsSep " " go v);
+    (lib.concatMapStringsSep " " go v);
 
   escapeAttrName = str:
     if match "[a-zA-Z_][-a-zA-Z0-9_']+" str != null
@@ -20,7 +21,7 @@ let
 
   printAttrs = v:
     wrap "{ " " }"
-      (concatStringsSep " " (lib.mapAttrsToList printAttr v));
+    (concatStringsSep " " (lib.mapAttrsToList printAttr v));
 
   go = v:
     if isList v
@@ -31,4 +32,4 @@ let
     then "<LAMBDA>"
     else toJSON v;
 in
-go
+  go

--- a/pkgs/build-support/utils/dropWhile.nix
+++ b/pkgs/build-support/utils/dropWhile.nix
@@ -1,11 +1,10 @@
 pred:
-with builtins;
-let
+with builtins; let
   go = items:
     if length items == 0
-    then [ ]
+    then []
     else if ! (pred (head items))
     then items
     else go (tail items);
 in
-go
+  go

--- a/pkgs/build-support/utils/takeWhile.nix
+++ b/pkgs/build-support/utils/takeWhile.nix
@@ -1,11 +1,10 @@
 pred:
-with builtins;
-let
+with builtins; let
   go = acc: items:
     if length items == 0
     then acc
     else if !(pred (head items))
     then acc
-    else go (acc ++ [ (head items) ]) (tail items);
+    else go (acc ++ [(head items)]) (tail items);
 in
-go [ ]
+  go []

--- a/pkgs/build-support/utils/trimLeft.nix
+++ b/pkgs/build-support/utils/trimLeft.nix
@@ -1,3 +1,3 @@
 s:
 with builtins;
-head (match "[[:space:]]*(.*)" s)
+  head (match "[[:space:]]*(.*)" s)

--- a/pkgs/build-support/utils/trimRight.nix
+++ b/pkgs/build-support/utils/trimRight.nix
@@ -1,8 +1,7 @@
 s:
-with builtins;
-let
+with builtins; let
   matchResult = match ".*[^[:space:]]([[:space:]]+)" s;
 in
-if matchResult == null
-then s
-else substring 0 (stringLength s - (stringLength (head matchResult))) s
+  if matchResult == null
+  then s
+  else substring 0 (stringLength s - (stringLength (head matchResult))) s

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,11 +1,8 @@
-inputs:
-final: pkgs:
-let
+inputs: final: pkgs: let
   lib = import ./build-support {
     inherit inputs pkgs;
   };
-in
-{
+in {
   emacsTwist = lib.makeOverridable (import ./emacs {
     inherit final pkgs lib;
   });

--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -1,17 +1,22 @@
-{ lib, stdenv, emacs, texinfo, gnumake }:
-{ ename
-, src
-, version
-, files
-, lispFiles
-, meta
-, nativeCompileAhead
-, wantExtraOutputs
-, elispInputs
-, ...
+{
+  lib,
+  stdenv,
+  emacs,
+  texinfo,
+  gnumake,
+}: {
+  ename,
+  src,
+  version,
+  files,
+  lispFiles,
+  meta,
+  nativeCompileAhead,
+  wantExtraOutputs,
+  elispInputs,
+  ...
 } @ attrs:
-with builtins;
-let
+with builtins; let
   nativeComp = emacs.nativeComp or false;
 
   regex = ".*/([^/]+)";
@@ -25,188 +30,186 @@ let
 
   canProduceInfo = hasFile (f: match ".+\\.(info|texi(nfo)?)" f != null);
 
-  copySourceCommand =
-    concatStringsSep "\n" (lib.mapAttrsToList
-      (origin: dest:
-        ''
-          mkdir -p $(dirname "build/${dest}")
-          cp -r "$src/${origin}" "build/${dest}"
-        ''
-      )
-      files);
-in
-stdenv.mkDerivation {
-  inherit src ename meta version;
-
-  pname = concatStringsSep "-" [
-    (replaceStrings [ "." ] [ "-" ] emacs.name)
-    (lib.toPName ename)
-  ];
-
-  preferLocalBuild = true;
-  allowSubstitutes = false;
-
-  outputs =
-    [ "out" ]
-    ++ lib.optional (wantExtraOutputs && canProduceInfo) "info";
-
-  buildInputs = [ emacs gnumake ] ++ lib.optional wantExtraOutputs texinfo;
-  # nativeBuildInputs = lib.optional nativeComp gcc;
-
-  # If the repository contains a Makefile, configurePhase can be problematic, so
-  # exclude it.
-  phases = [ "unpackPhase" "buildPhase" "checkPhase" "installPhase" ];
-
-  # False by default; You can override this later
-  doCheck = false;
-
-  renamePhase = lib.optionalString (attrs ? renames && attrs.renames != null) (
-    lib.pipe attrs.renames [
-      (lib.mapAttrsToList (origin: dest:
-        "mv ${
-          if lib.hasSuffix "/" origin
-          then origin + "*.*"
-          else lib.removeSuffix "/" origin
-        } ${
-          if dest == ""
-          then "."
-          else dest
-        }"
-      ))
-      (concatStringsSep "\n")
-    ]
-  );
-
-  preBuild = attrs.preBuild or "";
-
-  setSourceRoot =
-    if attrs.doTangle
-    then
+  copySourceCommand = concatStringsSep "\n" (lib.mapAttrsToList
+    (
+      origin: dest: ''
+        mkdir -p $(dirname "build/${dest}")
+        cp -r "$src/${origin}" "build/${dest}"
       ''
+    )
+    files);
+in
+  stdenv.mkDerivation {
+    inherit src ename meta version;
+
+    pname = concatStringsSep "-" [
+      (replaceStrings ["."] ["-"] emacs.name)
+      (lib.toPName ename)
+    ];
+
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+
+    outputs =
+      ["out"]
+      ++ lib.optional (wantExtraOutputs && canProduceInfo) "info";
+
+    buildInputs = [emacs gnumake] ++ lib.optional wantExtraOutputs texinfo;
+    # nativeBuildInputs = lib.optional nativeComp gcc;
+
+    # If the repository contains a Makefile, configurePhase can be problematic, so
+    # exclude it.
+    phases = ["unpackPhase" "buildPhase" "checkPhase" "installPhase"];
+
+    # False by default; You can override this later
+    doCheck = false;
+
+    renamePhase = lib.optionalString (attrs ? renames && attrs.renames != null) (
+      lib.pipe attrs.renames [
+        (lib.mapAttrsToList (
+          origin: dest: "mv ${
+            if lib.hasSuffix "/" origin
+            then origin + "*.*"
+            else lib.removeSuffix "/" origin
+          } ${
+            if dest == ""
+            then "."
+            else dest
+          }"
+        ))
+        (concatStringsSep "\n")
+      ]
+    );
+
+    preBuild = attrs.preBuild or "";
+
+    setSourceRoot =
+      if attrs.doTangle
+      then ''
         mkdir build
         ${copySourceCommand}
         sourceRoot="$PWD/build"
       ''
-    else "";
+      else "";
 
-  buildPhase = ''
-    export EMACSLOADPATH
-    runHook renamePhase
+    buildPhase = ''
+      export EMACSLOADPATH
+      runHook renamePhase
 
-    runHook preBuild
-    runHook buildCmd
-    runHook postBuild
+      runHook preBuild
+      runHook buildCmd
+      runHook postBuild
 
-    if [[ " ''${outputs[*]} " = *" info "* ]]
-    then
-      runHook buildInfo
-    fi
-  '';
-
-  buildInfo = ''
-    cwd="$PWD"
-    cd $src
-    for d in $(find -name '*.texi' -o -name '*.texinfo')
-    do
-      local basename=$(basename $d)
-      local i=$cwd/''${basename%%.*}.info
-      if [[ ! -e "$i" ]]
+      if [[ " ''${outputs[*]} " = *" info "* ]]
       then
-        cd $src/$(dirname $d)
-        makeinfo --no-split "$basename" -o "$i"
+        runHook buildInfo
       fi
-    done
-    cd $cwd
-  '';
+    '';
 
-  EMACSLOADPATH = lib.concatStrings
-    (map (pkg: "${pkg.outPath}/share/emacs/site-lisp/:")
-      elispInputs);
-
-  EMACSNATIVELOADPATH = "${
-    lib.makeSearchPath "share/emacs/native-lisp/" elispInputs
-  }:";
-
-  dontByteCompile = false;
-  errorOnWarn = false;
-
-  buildCmd = ''
-    # Don't make the package description of package.el available
-    rm -f *-pkg.el
-
-    if [[ ! -n "$dontByteCompile" ]]
-    then
-      (
-        if [[ -n "$errorOnWarn" ]]
+    buildInfo = ''
+      cwd="$PWD"
+      cd $src
+      for d in $(find -name '*.texi' -o -name '*.texinfo')
+      do
+        local basename=$(basename $d)
+        local i=$cwd/''${basename%%.*}.info
+        if [[ ! -e "$i" ]]
         then
-          byte_compile_error_on_warn=t
-        else
-          byte_compile_error_on_warn=nil
+          cd $src/$(dirname $d)
+          makeinfo --no-split "$basename" -o "$i"
         fi
-        # TODO: Add support for byte-compiling files separately
-        emacs --batch -L . \
-          --eval "(setq byte-compile-error-on-warn ''${byte_compile_error_on_warn})" \
-          -f batch-byte-compile ${lib.escapeShellArgs (map stringBaseName lispFiles)}
-      )
-    fi
+      done
+      cd $cwd
+    '';
 
-    rm -f "${ename}-autoloads.el"
-    emacs --batch -l autoload \
-        --eval "(setq backup-inhibited t)" \
-        --eval "(setq version-control 'never)" \
-        --eval "(setq generated-autoload-file \"$PWD/${ename}-autoloads.el\")" \
-        -f batch-update-autoloads .
-  '';
+    EMACSLOADPATH =
+      lib.concatStrings
+      (map (pkg: "${pkg.outPath}/share/emacs/site-lisp/:")
+        elispInputs);
 
-  # Because eln depends on the file name hash of the source file, native
-  # compilation must be done after the elisp files are installed. For details,
-  # see the documentation of comp-el-to-eln-rel-filename.
-  buildAndInstallNativeLisp = ''
-    nativeLispDir=$out/share/emacs/native-lisp
-    mkdir -p $nativeLispDir
+    EMACSNATIVELOADPATH = "${
+      lib.makeSearchPath "share/emacs/native-lisp/" elispInputs
+    }:";
 
-    EMACSLOADPATH="$EMACSLOADPATH" EMACSNATIVELOADPATH="$EMACSNATIVELOADPATH" \
-      emacs --batch -L $lispDir -l ${./comp-native.el} \
-        --eval "(push \"$nativeLispDir/\" native-comp-eln-load-path)" \
-        --eval "(setq native-compile-target-directory \"$nativeLispDir/\")" \
-        -f run-native-compile-sync $lispDir
-  '';
+    dontByteCompile = false;
+    errorOnWarn = false;
 
-  doNativeComp = nativeComp && nativeCompileAhead;
+    buildCmd = ''
+      # Don't make the package description of package.el available
+      rm -f *-pkg.el
 
-  installPhase = ''
-    runHook preInstall
+      if [[ ! -n "$dontByteCompile" ]]
+      then
+        (
+          if [[ -n "$errorOnWarn" ]]
+          then
+            byte_compile_error_on_warn=t
+          else
+            byte_compile_error_on_warn=nil
+          fi
+          # TODO: Add support for byte-compiling files separately
+          emacs --batch -L . \
+            --eval "(setq byte-compile-error-on-warn ''${byte_compile_error_on_warn})" \
+            -f batch-byte-compile ${lib.escapeShellArgs (map stringBaseName lispFiles)}
+        )
+      fi
 
-    lispDir=$out/share/emacs/site-lisp/
-    install -d $lispDir
-    tar cf - \
-      --exclude='*.info' \
-      --exclude='*.texi' \
-      --exclude='*.texinfo' \
-      --exclude='eln-cache' \
-      . \
-      | (cd $lispDir && tar xf -)
+      rm -f "${ename}-autoloads.el"
+      emacs --batch -l autoload \
+          --eval "(setq backup-inhibited t)" \
+          --eval "(setq version-control 'never)" \
+          --eval "(setq generated-autoload-file \"$PWD/${ename}-autoloads.el\")" \
+          -f batch-update-autoloads .
+    '';
 
-    if ! [[ -n "$dontByteCompile" ]] && [[ -n "$doNativeComp" ]]
-    then
-      runHook buildAndInstallNativeLisp
-    fi
+    # Because eln depends on the file name hash of the source file, native
+    # compilation must be done after the elisp files are installed. For details,
+    # see the documentation of comp-el-to-eln-rel-filename.
+    buildAndInstallNativeLisp = ''
+      nativeLispDir=$out/share/emacs/native-lisp
+      mkdir -p $nativeLispDir
 
-    if [[ " ''${outputs[*]} " = *" info "* ]]
-    then
-      runHook installInfo
-    fi
+      EMACSLOADPATH="$EMACSLOADPATH" EMACSNATIVELOADPATH="$EMACSNATIVELOADPATH" \
+        emacs --batch -L $lispDir -l ${./comp-native.el} \
+          --eval "(push \"$nativeLispDir/\" native-comp-eln-load-path)" \
+          --eval "(setq native-compile-target-directory \"$nativeLispDir/\")" \
+          -f run-native-compile-sync $lispDir
+    '';
 
-    runHook postInstall
-  '';
+    doNativeComp = nativeComp && nativeCompileAhead;
 
-  installInfo = ''
-    mkdir -p $info/share
-    install -d $info/share/info
-    for i in ${ename}*.info
-    do
-      install -t $info/share/info $i
-    done
-  '';
+    installPhase = ''
+      runHook preInstall
 
-}
+      lispDir=$out/share/emacs/site-lisp/
+      install -d $lispDir
+      tar cf - \
+        --exclude='*.info' \
+        --exclude='*.texi' \
+        --exclude='*.texinfo' \
+        --exclude='eln-cache' \
+        . \
+        | (cd $lispDir && tar xf -)
+
+      if ! [[ -n "$dontByteCompile" ]] && [[ -n "$doNativeComp" ]]
+      then
+        runHook buildAndInstallNativeLisp
+      fi
+
+      if [[ " ''${outputs[*]} " = *" info "* ]]
+      then
+        runHook installInfo
+      fi
+
+      runHook postInstall
+    '';
+
+    installInfo = ''
+      mkdir -p $info/share
+      install -d $info/share/info
+      for i in ${ename}*.info
+      do
+        install -t $info/share/info $i
+      done
+    '';
+  }

--- a/pkgs/emacs/builtins.nix
+++ b/pkgs/emacs/builtins.nix
@@ -1,43 +1,46 @@
-{ stdenv, emacs, ripgrep }:
-let
+{
+  stdenv,
+  emacs,
+  ripgrep,
+}: let
   inherit (emacs) version;
 in
-stdenv.mkDerivation {
-  name = "${emacs.name}-libraries";
-  inherit (emacs) src;
+  stdenv.mkDerivation {
+    name = "${emacs.name}-libraries";
+    inherit (emacs) src;
 
-  preferLocalBuild = true;
-  allowSubstitutes = false;
+    preferLocalBuild = true;
+    allowSubstitutes = false;
 
-  buildInputs = [ ripgrep ];
+    buildInputs = [ripgrep];
 
-  phases = [ "unpackPhase" "buildPhase" ];
+    phases = ["unpackPhase" "buildPhase"];
 
-  buildPhase = ''
-    echo "Comparing Emacs versions..."
-    decl=$(grep -oP "This directory tree holds version \d[.\d]+\d of GNU Emacs" README)
-    if [[ "$decl" =~ [1-9][.0-9]+[0-9] ]]
-    then
-      version=''${BASH_REMATCH[0]}
-      echo "  Expected: ${version}"
-      echo "  Actual:   $version"
-      if [[ $version != ${version} ]]
+    buildPhase = ''
+      echo "Comparing Emacs versions..."
+      decl=$(grep -oP "This directory tree holds version \d[.\d]+\d of GNU Emacs" README)
+      if [[ "$decl" =~ [1-9][.0-9]+[0-9] ]]
       then
-        echo "ERROR: The version mismatched. Please fix the version."
+        version=''${BASH_REMATCH[0]}
+        echo "  Expected: ${version}"
+        echo "  Actual:   $version"
+        if [[ $version != ${version} ]]
+        then
+          echo "ERROR: The version mismatched. Please fix the version."
+          exit 1
+        fi
+      else
+        echo "Did not find a version from the README." >&2
         exit 1
       fi
-    else
-      echo "Did not find a version from the README." >&2
-      exit 1
-    fi
 
-    cd lisp
-    rg --maxdepth 2 --files-with-matches -g '*.el' \
-      'This file is part of GNU Emacs.' \
-      | grep -o -E '([^/]+)\.el' \
-      | sed -e 's/\.el$//' \
-      | sort \
-      | uniq \
-      > $out
-  '';
-}
+      cd lisp
+      rg --maxdepth 2 --files-with-matches -g '*.el' \
+        'This file is part of GNU Emacs.' \
+        | grep -o -E '([^/]+)\.el' \
+        | sed -e 's/\.el$//' \
+        | sort \
+        | uniq \
+        > $out
+    '';
+  }

--- a/pkgs/emacs/data/default.nix
+++ b/pkgs/emacs/data/default.nix
@@ -1,99 +1,121 @@
 let
-  inherit (builtins) length head tail hasAttr filter elem mapAttrs readFile
-    pathExists concatLists isFunction removeAttrs attrNames foldl' listToAttrs;
+  inherit
+    (builtins)
+    length
+    head
+    tail
+    hasAttr
+    filter
+    elem
+    mapAttrs
+    readFile
+    pathExists
+    concatLists
+    isFunction
+    removeAttrs
+    attrNames
+    foldl'
+    listToAttrs
+    ;
 in
-{ lib
-, builtinLibraries
-, inventories
-, flakeLockFile
-, archiveLockFile
-, inputOverrides
-, elispPackagePins
-}:
-mode:
-let
-  toLockData = { nodes, version, ... }:
-    if version == 7
-    then lib.mapAttrs (_: { locked, ... }: locked) nodes
-    else throw "Unsupported flake.lock version ${version}";
+  {
+    lib,
+    builtinLibraries,
+    inventories,
+    flakeLockFile,
+    archiveLockFile,
+    inputOverrides,
+    elispPackagePins,
+  }: mode: let
+    toLockData = {
+      nodes,
+      version,
+      ...
+    }:
+      if version == 7
+      then lib.mapAttrs (_: {locked, ...}: locked) nodes
+      else throw "Unsupported flake.lock version ${version}";
 
-  flakeLockData =
-    if pathExists flakeLockFile
-    then toLockData (lib.importJSON flakeLockFile)
-    else { };
+    flakeLockData =
+      if pathExists flakeLockFile
+      then toLockData (lib.importJSON flakeLockFile)
+      else {};
 
-  archiveLockData =
-    if pathExists archiveLockFile
-    then lib.importJSON archiveLockFile
-    else { };
+    archiveLockData =
+      if pathExists archiveLockFile
+      then lib.importJSON archiveLockFile
+      else {};
 
-  makeInventory = import ./inventory {
-    inherit lib flakeLockData archiveLockData;
-  };
+    makeInventory = import ./inventory {
+      inherit lib flakeLockData archiveLockData;
+    };
 
-  inventoryPackageSets =
-    map
+    inventoryPackageSets =
+      map
       (spec: {
         name = spec.name or null;
         value = makeInventory spec mode;
       })
       inventories;
 
-  namedInventories = lib.pipe inventoryPackageSets [
-    (filter ({ name, ... }: name != null))
-    listToAttrs
-  ];
-
-  packageData = foldl' (acc: { value, ... }: value // acc) { } inventoryPackageSets;
-
-  findPrescription = ename:
-    packageData.${ename} or (throw "Package ${ename} is not found");
-
-  findFromPinned = ename: inventory:
-    if hasAttr ename inventory
-    then inventory.${ename}
-    else if inventory ? _impure
-    then inventory._impure.${ename}
-    else throw "Package ${ename} does not exist in the pinned inventory";
-
-  findPrescription' = ename: pin:
-    if pin == null
-    then findPrescription ename
-    else
-      findFromPinned ename
-        (
-          namedInventories.${pin}
-            or (throw "Inventory named ${pin} does not exist")
-        );
-
-  getPackageData = ename:
-    lib.makeExtensible (import ./package.nix { inherit lib; }
-      ename
-      # It would be nice if it were possible to set the pin from inside
-      # overrideInputs, but it causes infinite recursion unfortunately :(
-      (findPrescription' ename (elispPackagePins.${ename} or null)));
-
-  toOverrideFn = overrides:
-    if isFunction overrides
-    then overrides
-    else _: _: overrides;
-
-  getPackageData' = ename: lib.pipe
-    # Because this extending operation affects which packages are included in the
-    # output, it must be done before the entire package set is calculated.
-    (if hasAttr ename inputOverrides
-    then (getPackageData ename).extend (toOverrideFn inputOverrides.${ename})
-    else getPackageData ename)
-    [
-      # The user should not call extend after the package set is calculated, so
-      # remove it here.
-      (lib.flip removeAttrs [ "extend" ])
-      (lib.filterAttrs (_: v: v != null))
+    namedInventories = lib.pipe inventoryPackageSets [
+      (filter ({name, ...}: name != null))
+      listToAttrs
     ];
 
-  go = acc: enames: ename: data:
-    accumPackage
-      (acc // { ${ename} = data; })
+    packageData = foldl' (acc: {value, ...}: value // acc) {} inventoryPackageSets;
+
+    findPrescription = ename:
+      packageData.${ename} or (throw "Package ${ename} is not found");
+
+    findFromPinned = ename: inventory:
+      if hasAttr ename inventory
+      then inventory.${ename}
+      else if inventory ? _impure
+      then inventory._impure.${ename}
+      else throw "Package ${ename} does not exist in the pinned inventory";
+
+    findPrescription' = ename: pin:
+      if pin == null
+      then findPrescription ename
+      else
+        findFromPinned ename
+        (
+          namedInventories.${pin}
+          or (throw "Inventory named ${pin} does not exist")
+        );
+
+    getPackageData = ename:
+      lib.makeExtensible (import ./package.nix {inherit lib;}
+        ename
+        # It would be nice if it were possible to set the pin from inside
+        # overrideInputs, but it causes infinite recursion unfortunately :(
+        (findPrescription' ename (elispPackagePins.${ename} or null)));
+
+    toOverrideFn = overrides:
+      if isFunction overrides
+      then overrides
+      else _: _: overrides;
+
+    getPackageData' = ename:
+      lib.pipe
+      # Because this extending operation affects which packages are included in the
+      # output, it must be done before the entire package set is calculated.
+      (
+        if hasAttr ename inputOverrides
+        then (getPackageData ename).extend (toOverrideFn inputOverrides.${ename})
+        else getPackageData ename
+      )
+      [
+        # The user should not call extend after the package set is calculated, so
+        # remove it here.
+        (lib.flip removeAttrs ["extend"])
+        (lib.filterAttrs (_: v: v != null))
+      ];
+
+    go = acc: enames: ename: data:
+      accumPackage
+      (acc // {${ename} = data;})
       (enames
         ++
         # Reduce the list as much as possible to keep the stack trace sane.
@@ -101,14 +123,14 @@ let
           (builtinLibraries ++ attrNames acc ++ enames)
           (lib.packageRequiresToLibraryNames data.packageRequires)));
 
-  # This recursion produces a deep stack trace. The more packages you have, the
-  # more traces it will produce. I want to avoid it, but I don't know how,
-  # because Nix doesn't support mutable data structures.
-  accumPackage = acc: enames:
-    if length enames == 0
-    then acc
-    else if hasAttr (head enames) acc
-    then accumPackage acc (tail enames)
-    else go acc enames (head enames) (getPackageData' (head enames));
-in
-accumPackage { }
+    # This recursion produces a deep stack trace. The more packages you have, the
+    # more traces it will produce. I want to avoid it, but I don't know how,
+    # because Nix doesn't support mutable data structures.
+    accumPackage = acc: enames:
+      if length enames == 0
+      then acc
+      else if hasAttr (head enames) acc
+      then accumPackage acc (tail enames)
+      else go acc enames (head enames) (getPackageData' (head enames));
+  in
+    accumPackage {}

--- a/pkgs/emacs/data/headers-to-meta.nix
+++ b/pkgs/emacs/data/headers-to-meta.nix
@@ -1,22 +1,22 @@
-{ lib
-, headers
-}:
-let
+{
+  lib,
+  headers,
+}: let
   inherit (builtins) isString isList;
 in
-lib.filterAttrs (_: v: v != null) {
-  description = headers.summary or null;
-  homepage = headers.URL or null;
-  license =
-    if headers ? SPDX-License-Identifier
-    then lib.findLicense headers.SPDX-License-Identifier
-    else null;
-  maintainers =
-    if ! headers ? Maintainer
-    then null
-    else if isString headers.Maintainer
-    then [ headers.Maintainer ]
-    else if isList headers.Maintainer
-    then headers.Maintainer
-    else null;
-}
+  lib.filterAttrs (_: v: v != null) {
+    description = headers.summary or null;
+    homepage = headers.URL or null;
+    license =
+      if headers ? SPDX-License-Identifier
+      then lib.findLicense headers.SPDX-License-Identifier
+      else null;
+    maintainers =
+      if ! headers ? Maintainer
+      then null
+      else if isString headers.Maintainer
+      then [headers.Maintainer]
+      else if isList headers.Maintainer
+      then headers.Maintainer
+      else null;
+  }

--- a/pkgs/emacs/data/inventory/default.nix
+++ b/pkgs/emacs/data/inventory/default.nix
@@ -1,26 +1,26 @@
-{ lib
-, flakeLockData
-, archiveLockData
-}:
-{ type
-, ...
-} @ inventory:
-with builtins;
-let
-  args = removeAttrs inventory [ "type" "name" "exclude" ];
+{
+  lib,
+  flakeLockData,
+  archiveLockData,
+}: {type, ...} @ inventory:
+with builtins; let
+  args = removeAttrs inventory ["type" "name" "exclude"];
 in
-mode:
-removeAttrs
-  (
-    (if type == "melpa"
-    then import ./melpa.nix { inherit lib flakeLockData; }
-     else if type == "elpa"
-     then import ./elpa.nix { inherit lib flakeLockData; }
-    else if type == "archive"
-    then import ./archive.nix { inherit lib archiveLockData; }
-    else if type == "gitmodules"
-    then import ./gitmodules.nix { inherit lib flakeLockData; }
-    else throw "Unsupported inventory type: ${type}")
+  mode:
+    removeAttrs
+    (
+      (
+        if type == "melpa"
+        then import ./melpa.nix {inherit lib flakeLockData;}
+        else if type == "elpa"
+        then import ./elpa.nix {inherit lib flakeLockData;}
+        else if type == "archive"
+        then import ./archive.nix {inherit lib archiveLockData;}
+        else if type == "gitmodules"
+        then import ./gitmodules.nix {inherit lib flakeLockData;}
+        else throw "Unsupported inventory type: ${type}"
+      )
       args
-      mode)
-  (inventory.exclude or [ ])
+      mode
+    )
+    (inventory.exclude or [])

--- a/pkgs/emacs/data/inventory/elpa.nix
+++ b/pkgs/emacs/data/inventory/elpa.nix
@@ -1,71 +1,77 @@
-{ lib
-, flakeLockData
+{
+  lib,
+  flakeLockData,
 }:
 with builtins;
-{ path
-, ...
-} @ args:
-let
-  elpaEntries = lib.parseElpaPackages (readFile path);
+  {path, ...} @ args: let
+    elpaEntries = lib.parseElpaPackages (readFile path);
 
-  inventory = args // {
-    type = "elpa";
-  };
+    inventory =
+      args
+      // {
+        type = "elpa";
+      };
 
-  fileListToAttrs = files: lib.pipe files [
-    (map (name: {
-      inherit name;
-      value = baseNameFromString name;
-    }))
-    listToAttrs    
-  ];
-
-  corePackages =
-    if args ? core-src
-    then
-      lib.pipe elpaEntries [
-        (lib.filterAttrs (_: entry: entry ? core))
-        (lib.mapAttrs (_: { core, ... } @ entry:
-          {
-            inherit inventory;
-            src = args.core-src;
-            doTangle = true;
-            files =
-              fileListToAttrs
-                (if isString core
-                 then [ core ]
-                 else core);
-          }
-        ))
-      ]
-    else { };
-
-  toList = x: if isList x then x else [ x ];
-
-  globToRegex = replaceStrings [ "?" "*" "." ] [ "." ".*" "\\." ];
-
-  filesInDir = src: dir:
-    if dir == ""
-    then
-      lib.pipe (readDir src) [
-        attrNames
-      ] else
-      lib.pipe (readDir (src + "/${dir}")) [
-        attrNames
-        (map (name: dir + "/" + name))
+    fileListToAttrs = files:
+      lib.pipe files [
+        (map (name: {
+          inherit name;
+          value = baseNameFromString name;
+        }))
+        listToAttrs
       ];
 
-  isElisp = lib.hasSuffix ".el";
+    corePackages =
+      if args ? core-src
+      then
+        lib.pipe elpaEntries [
+          (lib.filterAttrs (_: entry: entry ? core))
+          (lib.mapAttrs (
+            _: {core, ...} @ entry: {
+              inherit inventory;
+              src = args.core-src;
+              doTangle = true;
+              files =
+                fileListToAttrs
+                (
+                  if isString core
+                  then [core]
+                  else core
+                );
+            }
+          ))
+        ]
+      else {};
 
-  baseNameRegexp = ".+/([^/]+)";
+    toList = x:
+      if isList x
+      then x
+      else [x];
 
-  baseNameFromString = pathString:
-    if match baseNameRegexp pathString != null
-    then head (match baseNameRegexp pathString)
-    else pathString;
+    globToRegex = replaceStrings ["?" "*" "."] ["." ".*" "\\."];
 
-  makeExternal = ename: entry:
-    let
+    filesInDir = src: dir:
+      if dir == ""
+      then
+        lib.pipe (readDir src) [
+          attrNames
+        ]
+      else
+        lib.pipe (readDir (src + "/${dir}")) [
+          attrNames
+          (map (name: dir + "/" + name))
+        ];
+
+    isElisp = lib.hasSuffix ".el";
+
+    baseNameRegexp = ".+/([^/]+)";
+
+    baseNameFromString = pathString:
+      if match baseNameRegexp pathString != null
+      then head (match baseNameRegexp pathString)
+      else pathString;
+
+    makeExternal = ename: entry: let
       ignorePatterns = map globToRegex entry.ignored-files;
 
       p =
@@ -73,70 +79,84 @@ let
         then file: all (pattern: match pattern file == null) ignorePatterns
         else _: true;
     in
-    self:
-    {
-      doTangle = true;
-      src =
-        if hasAttr ename flakeLockData
-        then fetchTree flakeLockData.${ename}
-        else fetchTree self.origin;
-      origin = lib.flakeRefAttrsFromElpaAttrs { preferReleaseBranch = true; } entry;
-      inventory = inventory // { inherit entry; };
+      self:
+        {
+          doTangle = true;
+          src =
+            if hasAttr ename flakeLockData
+            then fetchTree flakeLockData.${ename}
+            else fetchTree self.origin;
+          origin = lib.flakeRefAttrsFromElpaAttrs {preferReleaseBranch = true;} entry;
+          inventory = inventory // {inherit entry;};
 
-      # FIXME: I don't exactly understand how the specs of ELPA work.
-      files = lib.pipe
-        (
-          ((if entry ? lisp-dir
-          then filter (file: ! isElisp file)
-          else lib.id)
-            (filesInDir self.src "")
-          )
-          ++
-          (if entry ? lisp-dir then filter isElisp (filesInDir self.src entry.lisp-dir) else [ ])
-          ++
-          (if entry ? doc then toList entry.doc else [ ])
-          ++
-          (if entry ? texinfo then toList entry.texinfo else [ ])
-        ) [
-        (filter (file: ! (file == ".dir-locals.el" || match "(.+-)?tests?\.el" file != null)))
-        (filter p)
-        fileListToAttrs
-      ];
+          # FIXME: I don't exactly understand how the specs of ELPA work.
+          files =
+            lib.pipe
+            (
+              (
+                (
+                  if entry ? lisp-dir
+                  then filter (file: ! isElisp file)
+                  else lib.id
+                )
+                (filesInDir self.src "")
+              )
+              ++ (
+                if entry ? lisp-dir
+                then filter isElisp (filesInDir self.src entry.lisp-dir)
+                else []
+              )
+              ++ (
+                if entry ? doc
+                then toList entry.doc
+                else []
+              )
+              ++ (
+                if entry ? texinfo
+                then toList entry.texinfo
+                else []
+              )
+            ) [
+              (filter (file: ! (file == ".dir-locals.el" || match "(.+-)?tests?\.el" file != null)))
+              (filter p)
+              fileListToAttrs
+            ];
 
-      preBuild =
-        # There are not so many packages that have :make attribute.
-        # Only in GNU, and not in non-GNU.
-        lib.optionalString (entry ? make) ''
-          make ${lib.escapeShellArgs (toList entry.make)}
-        '';
-    }
-    //
-    lib.optionalAttrs (entry ? renames) {
-      renames = lib.pipe entry.renames [
-        (map (xs: {
-          name = elemAt xs 0;
-          value = elemAt xs 1;
-        }))
-        listToAttrs
-      ];
-    }
-    //
-    # Only tramp has this attribute.
-    lib.optionalAttrs (entry ? main-file) {
-      mainFile = entry.main-file;
-    };
+          preBuild =
+            # There are not so many packages that have :make attribute.
+            # Only in GNU, and not in non-GNU.
+            lib.optionalString (entry ? make) ''
+              make ${lib.escapeShellArgs (toList entry.make)}
+            '';
+        }
+        // lib.optionalAttrs (entry ? renames) {
+          renames = lib.pipe entry.renames [
+            (map (xs: {
+              name = elemAt xs 0;
+              value = elemAt xs 1;
+            }))
+            listToAttrs
+          ];
+        }
+        //
+        # Only tramp has this attribute.
+        lib.optionalAttrs (entry ? main-file) {
+          mainFile = entry.main-file;
+        };
 
-  checkUrl = url: url != null && ! lib.hasPrefix "bzr::" url;
+    checkUrl = url: url != null && ! lib.hasPrefix "bzr::" url;
 
-  filterAutoSync = (lib.filterAttrs (_: entry: entry ? auto-sync));
+    filterAutoSync = lib.filterAttrs (_: entry: entry ? auto-sync);
 
-  externalPackages = lib.pipe elpaEntries [
-    (if args ? auto-sync-only && args.auto-sync-only
-    then filterAutoSync
-    else lib.id)
-    (lib.filterAttrs (_: entry: entry ? url && checkUrl entry.url))
-    (lib.mapAttrs makeExternal)
-  ];
-in
-_mode:
-corePackages // externalPackages
+    externalPackages = lib.pipe elpaEntries [
+      (
+        if args ? auto-sync-only && args.auto-sync-only
+        then filterAutoSync
+        else lib.id
+      )
+      (lib.filterAttrs (_: entry: entry ? url && checkUrl entry.url))
+      (lib.mapAttrs makeExternal)
+    ];
+  in
+    _mode:
+      corePackages // externalPackages

--- a/pkgs/emacs/data/inventory/gitmodules.nix
+++ b/pkgs/emacs/data/inventory/gitmodules.nix
@@ -1,22 +1,21 @@
-{ lib
-, flakeLockData
+{
+  lib,
+  flakeLockData,
 }:
 with builtins;
-{ path
-}:
-_mode:
-lib.pipe (lib.readGitModulesFile path) [
-  (mapAttrs (ename: origin: self: {
-    src =
-      if hasAttr ename flakeLockData
-      then fetchTree flakeLockData.${ename}
-      else fetchTree self.origin;
-    doTangle = false;
-    files = lib.expandMelpaRecipeFiles self.src null;
-    inherit origin;
-    inventory = {
-      type = "gitmodules";
-      inherit path;
-    };
-  }))
-]
+  {path}: _mode:
+    lib.pipe (lib.readGitModulesFile path) [
+      (mapAttrs (ename: origin: self: {
+        src =
+          if hasAttr ename flakeLockData
+          then fetchTree flakeLockData.${ename}
+          else fetchTree self.origin;
+        doTangle = false;
+        files = lib.expandMelpaRecipeFiles self.src null;
+        inherit origin;
+        inventory = {
+          type = "gitmodules";
+          inherit path;
+        };
+      }))
+    ]

--- a/pkgs/emacs/data/inventory/melpa.nix
+++ b/pkgs/emacs/data/inventory/melpa.nix
@@ -1,32 +1,28 @@
-{ lib
-, flakeLockData
+{
+  lib,
+  flakeLockData,
 }:
-with builtins;
-let
-  fromEntry = inventory: { ename, ... } @ entry: self:
-    {
-      src =
-        if hasAttr ename flakeLockData
-        then fetchTree flakeLockData.${ename}
-        else fetchTree self.origin;
-      doTangle = true;
-      files = lib.expandMelpaRecipeFiles self.src (entry.files or null);
-      origin = lib.flakeRefAttrsFromMelpaRecipe entry;
-      inventory = inventory // { inherit entry; };
-    };
-in
-{ path
-}:
-let
-  inventory = {
-    type = "melpa";
-    inherit path;
+with builtins; let
+  fromEntry = inventory: {ename, ...} @ entry: self: {
+    src =
+      if hasAttr ename flakeLockData
+      then fetchTree flakeLockData.${ename}
+      else fetchTree self.origin;
+    doTangle = true;
+    files = lib.expandMelpaRecipeFiles self.src (entry.files or null);
+    origin = lib.flakeRefAttrsFromMelpaRecipe entry;
+    inventory = inventory // {inherit entry;};
   };
 in
-_mode:
-lib.pipe (readDir path) [
-  (lib.filterAttrs (_: type: type == "regular"))
-  (mapAttrs
-    (ename: _:
-      (fromEntry inventory (lib.parseMelpaRecipe (readFile (path + "/${ename}"))))))
-]
+  {path}: let
+    inventory = {
+      type = "melpa";
+      inherit path;
+    };
+  in
+    _mode:
+      lib.pipe (readDir path) [
+        (lib.filterAttrs (_: type: type == "regular"))
+        (mapAttrs
+          (ename: _: (fromEntry inventory (lib.parseMelpaRecipe (readFile (path + "/${ename}"))))))
+      ]

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -1,119 +1,136 @@
 let
-  inherit (builtins) pathExists fetchTree replaceStrings map readDir hasAttr
-    readFile attrNames filter all match isString isList typeOf length head toJSON
-    isAttrs isFunction;
-in
-{ lib
-}:
-ename:
-mkAttrs:
-self:
-let
-  attrs =
-    if isAttrs mkAttrs
-    then mkAttrs
-    else if isFunction mkAttrs
-    then mkAttrs self
-    else throw "Unsupported type: ${toJSON mkAttrs}";
-  pkgFiles = lib.pipe self.files [
+  inherit
+    (builtins)
+    pathExists
+    fetchTree
+    replaceStrings
+    map
+    readDir
+    hasAttr
+    readFile
     attrNames
-    (filter (filename: baseNameOf filename == ename + "-pkg.el"))
-  ];
-  pkgFile =
-    if length pkgFiles != 0
-    then self.src + "/${head pkgFiles}"
-    else self.src + "/${ename}-pkg.el";
-  #  OPTIMIZE: Reduce filesystem access
-  hasPkgFile =
-    ! (self.ignorePkgFile or false)
-    && (length pkgFiles != 0
-    || pathExists pkgFile);
-  packageDesc =
-    if hasPkgFile
-    then lib.parsePkg (readFile pkgFile)
-    else { };
-
-  # builtins.readFile fails when the source file contains control characters.
-  # pydoc.el is an example. A workaround is to take only the first N bytes of
-  # the file using `head` command and read its output.
-  headers = lib.parseElispHeaders
-    (lib.readFirstBytes
-      # magit.el has a relatively long header, so other libraries would be shorter.
-      1500
-      (self.src + "/${self.mainFile}"));
+    filter
+    all
+    match
+    isString
+    isList
+    typeOf
+    length
+    head
+    toJSON
+    isAttrs
+    isFunction
+    ;
 in
-lib.getAttrs
-  (filter (name: hasAttr name attrs) [
-    "entry"
-    "renames"
-    "origin"
-    "archive"
-    "preBuild"
-  ])
-  attrs
-  //
-{
-  inherit ename;
-  inherit (attrs) inventory doTangle;
-  src = attrs.src;
-
-  files = attrs.files or (lib.expandMelpaRecipeFiles self.src null);
-
-  lispFiles =
-    lib.pipe self.files [
-      # Some packages contain contributing files in a subdirectory. See slime,
-      # ESS, etc. They are usually not supposed to be byte-compiled.
-      (lib.filterAttrs (_: file: match "[^/]+\\.el" file != null))
+  {lib}: ename: mkAttrs: self: let
+    attrs =
+      if isAttrs mkAttrs
+      then mkAttrs
+      else if isFunction mkAttrs
+      then mkAttrs self
+      else throw "Unsupported type: ${toJSON mkAttrs}";
+    pkgFiles = lib.pipe self.files [
       attrNames
-      # *-pkg.el is not required unless you use package.el, and it makes
-      # *-byte-compile fail, so exclude them.
-      (filter (filename: match ".+-pkg\.el" filename == null))
+      (filter (filename: baseNameOf filename == ename + "-pkg.el"))
     ];
+    pkgFile =
+      if length pkgFiles != 0
+      then self.src + "/${head pkgFiles}"
+      else self.src + "/${ename}-pkg.el";
+    #  OPTIMIZE: Reduce filesystem access
+    hasPkgFile =
+      ! (self.ignorePkgFile or false)
+      && (length pkgFiles
+        != 0
+        || pathExists pkgFile);
+    packageDesc =
+      if hasPkgFile
+      then lib.parsePkg (readFile pkgFile)
+      else {};
 
-  mainFile =
-    if attrs ? mainFile
-    then attrs.mainFile
-    else
-      lib.findFirst
-        (file: baseNameOf file == ename + ".el")
-        (if length self.lispFiles > 0
-        then head self.lispFiles
+    # builtins.readFile fails when the source file contains control characters.
+    # pydoc.el is an example. A workaround is to take only the first N bytes of
+    # the file using `head` command and read its output.
+    headers =
+      lib.parseElispHeaders
+      (lib.readFirstBytes
+        # magit.el has a relatively long header, so other libraries would be shorter.
+        1500
+        (self.src + "/${self.mainFile}"));
+  in
+    lib.getAttrs
+    (filter (name: hasAttr name attrs) [
+      "entry"
+      "renames"
+      "origin"
+      "archive"
+      "preBuild"
+    ])
+    attrs
+    // {
+      inherit ename;
+      inherit (attrs) inventory doTangle;
+      src = attrs.src;
+
+      files = attrs.files or (lib.expandMelpaRecipeFiles self.src null);
+
+      lispFiles = lib.pipe self.files [
+        # Some packages contain contributing files in a subdirectory. See slime,
+        # ESS, etc. They are usually not supposed to be byte-compiled.
+        (lib.filterAttrs (_: file: match "[^/]+\\.el" file != null))
+        attrNames
+        # *-pkg.el is not required unless you use package.el, and it makes
+        # *-byte-compile fail, so exclude them.
+        (filter (filename: match ".+-pkg\.el" filename == null))
+      ];
+
+      mainFile =
+        if attrs ? mainFile
+        then attrs.mainFile
         else
-          throw ''
-            Package ${ename} contains no *.el file.
-            Check the contents in the store: ${self.src}
-            Files: ${toJSON self.lispFiles}
-            Entry: ${toJSON attrs.inventory}
-          '')
-        self.lispFiles;
+          lib.findFirst
+          (file: baseNameOf file == ename + ".el")
+          (
+            if length self.lispFiles > 0
+            then head self.lispFiles
+            else
+              throw ''
+                Package ${ename} contains no *.el file.
+                Check the contents in the store: ${self.src}
+                Files: ${toJSON self.lispFiles}
+                Entry: ${toJSON attrs.inventory}
+              ''
+          )
+          self.lispFiles;
 
-  inherit headers;
+      inherit headers;
 
-  # TODO: Check https://github.com/melpa/melpa/issues/2955 on the right versioning scheme
-  version =
-    attrs.version
-      or packageDesc.version
-      or headers.Version
-      or headers.Package-Version
-      # There are packages that lack a version header, so fallback to zero.
-      or "0.0.0";
+      # TODO: Check https://github.com/melpa/melpa/issues/2955 on the right versioning scheme
+      version =
+        attrs.version
+        or packageDesc.version
+        or headers.Version
+        or headers.Package-Version
+        # There are packages that lack a version header, so fallback to zero.
+        or "0.0.0";
 
-  author = headers.Author or null;
+      author = headers.Author or null;
 
-  meta =
-    (import ./headers-to-meta.nix {
-      inherit lib;
-      inherit (self) headers;
-    })
-    //
-    (lib.optionalAttrs hasPkgFile {
-      description = packageDesc.summary;
-    });
+      meta =
+        (import ./headers-to-meta.nix {
+          inherit lib;
+          inherit (self) headers;
+        })
+        // (lib.optionalAttrs hasPkgFile {
+          description = packageDesc.summary;
+        });
 
-  packageRequires =
-    attrs.packageRequires
-      or packageDesc.packageRequires
-      or (if headers ? Package-Requires
-    then lib.parsePackageRequireLines headers.Package-Requires
-    else { });
-}
+      packageRequires =
+        attrs.packageRequires
+        or packageDesc.packageRequires
+        or (
+          if headers ? Package-Requires
+          then lib.parsePackageRequireLines headers.Package-Requires
+          else {}
+        );
+    }

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -159,8 +159,7 @@ in
     # This makes the attrset a derivation for a shorthand.
     inherit (self.emacsWrapper) name type outputName outPath drvPath;
 
-    admin = lockDirName:
-      lib.extendDerivation true
+    makeApps = { lockDirName }:
       {
         # Generate flake.nix and archive.lock with a complete package set. You
         # have to run `nix flake lock`` in the target directory to update
@@ -190,9 +189,5 @@ in
             archiveLock = true;
           }
           lockDirName;
-      }
-      (pkgs.writeShellScriptBin "admin" ''
-        echo >&2 "Run .#admin.lock or .#admin.update"
-        exit 1
-      '');
+      };
   })

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -1,32 +1,32 @@
-{ lib
-, nix
-, nixfmt
-, jq
-, runCommandLocal
-, writeTextFile
-, writeShellScriptBin
-# Current version
-, flakeLockFile ? null
-}:
-{ packageInputs
-, flakeNix ? false
-, flakeLock ? false
-, archiveLock ? false
-, postCommand ? null
-}:
-outDir:
-assert (flakeNix || flakeLock || archiveLock);
-let
+{
+  lib,
+  nix,
+  nixfmt,
+  jq,
+  runCommandLocal,
+  writeTextFile,
+  writeShellScriptBin,
+  # Current version
+  flakeLockFile ? null,
+}: {
+  packageInputs,
+  flakeNix ? false,
+  flakeLock ? false,
+  archiveLock ? false,
+  postCommand ? null,
+}: outDir:
+assert (flakeNix || flakeLock || archiveLock); let
   inherit (builtins) toJSON attrNames mapAttrs;
 
   archiveLockData = lib.pipe packageInputs [
     (lib.filterAttrs (_: attrs: attrs ? archive))
-    (mapAttrs (_: lib.getAttrs [
-      "version"
-      "archive"
-      "packageRequires"
-      "inventory"
-    ]))
+    (mapAttrs (_:
+      lib.getAttrs [
+        "version"
+        "archive"
+        "packageRequires"
+        "inventory"
+      ]))
   ];
 
   data = {
@@ -34,9 +34,9 @@ let
       description = "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
       inputs = lib.pipe packageInputs [
         (lib.filterAttrs (_: attrs: attrs ? origin))
-        (lib.mapAttrs (_: { origin, ... }: origin // { flake = false; }))
+        (lib.mapAttrs (_: {origin, ...}: origin // {flake = false;}))
       ];
-      outputs = { ... }: { };
+      outputs = {...}: {};
     };
     flakeLock = toJSON (import ./flake-lock.nix {
       inherit lib flakeLockFile packageInputs;
@@ -46,8 +46,8 @@ let
 
   passAsFile =
     lib.optional flakeNix "flakeNix"
-      ++ lib.optional flakeLock "flakeLock"
-      ++ lib.optional archiveLock "archiveLock";
+    ++ lib.optional flakeLock "flakeLock"
+    ++ lib.optional archiveLock "archiveLock";
 
   # HACK: Use sed to convert JSON to Nix
   #
@@ -67,18 +67,20 @@ let
     ${jq}/bin/jq . "$archiveLockPath" > "$out/archive.lock"
   '';
 
-  src = runCommandLocal "emacs-twist-lock" ({
-    inherit passAsFile;
-  } // lib.getAttrs passAsFile data)
-  ''
-    mkdir -p $out
-  
-    ${lib.optionalString flakeNix generateFlakeNix}
-    ${lib.optionalString flakeLock generateFlakeLock}
-    ${lib.optionalString archiveLock generateArchiveLock}
-  '';
+  src =
+    runCommandLocal "emacs-twist-lock" ({
+        inherit passAsFile;
+      }
+      // lib.getAttrs passAsFile data)
+    ''
+      mkdir -p $out
 
-  writeToDir =  writeShellScriptBin "lock" ''
+      ${lib.optionalString flakeNix generateFlakeNix}
+      ${lib.optionalString flakeLock generateFlakeLock}
+      ${lib.optionalString archiveLock generateArchiveLock}
+    '';
+
+  writeToDir = writeShellScriptBin "lock" ''
     outDir="${outDir}"
 
     if [[ ! -d "$outDir" ]]
@@ -107,10 +109,11 @@ let
     ''}
   '';
 in
-lib.extendDerivation true {
-  inherit src;
+  lib.extendDerivation true {
+    inherit src;
 
-  # passthru.exePath is useful with flake-utils.lib.mkApp
-  # <https://github.com/numtide/flake-utils>
-  passthru.exePath = "/bin/lock";
-} writeToDir
+    # passthru.exePath is useful with flake-utils.lib.mkApp
+    # <https://github.com/numtide/flake-utils>
+    passthru.exePath = "/bin/lock";
+  }
+  writeToDir

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -5,7 +5,7 @@
   jq,
   runCommandLocal,
   writeTextFile,
-  writeShellScriptBin,
+  writeShellScript,
   # Current version
   flakeLockFile ? null,
 }: {
@@ -80,7 +80,7 @@ assert (flakeNix || flakeLock || archiveLock); let
       ${lib.optionalString archiveLock generateArchiveLock}
     '';
 
-  writeToDir = writeShellScriptBin "lock" ''
+  writeToDir = writeShellScript "lock" ''
     outDir="${outDir}"
 
     if [[ ! -d "$outDir" ]]
@@ -109,11 +109,9 @@ assert (flakeNix || flakeLock || archiveLock); let
     ''}
   '';
 in
-  lib.extendDerivation true {
-    inherit src;
-
-    # passthru.exePath is useful with flake-utils.lib.mkApp
-    # <https://github.com/numtide/flake-utils>
-    passthru.exePath = "/bin/lock";
+  # This is an app, and not a derivation. See
+  # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps
+  {
+    type = "app";
+    program = writeToDir.outPath;
   }
-  writeToDir

--- a/pkgs/emacs/lock/flake-lock.nix
+++ b/pkgs/emacs/lock/flake-lock.nix
@@ -1,8 +1,8 @@
-{ lib
-, flakeLockFile
-, packageInputs
-}:
-let
+{
+  lib,
+  flakeLockFile,
+  packageInputs,
+}: let
   inherit (builtins) intersectAttrs mapAttrs hasAttr throw;
 
   # It would be possible to generate an entirely new lock file, but I prefer not
@@ -11,17 +11,15 @@ let
 
   newNodeAttrs = attrs: value:
     if attrs ? origin && attrs.origin != null
-    then
-      rec {
-        original = attrs.origin;
-        locked = original // intersectAttrs value.locked attrs.src;
-      }
+    then rec {
+      original = attrs.origin;
+      locked = original // intersectAttrs value.locked attrs.src;
+    }
     else null;
 
   version7 =
     prev
-    //
-    {
+    // {
       nodes = lib.pipe prev.nodes [
         (mapAttrs
           (ename: value:
@@ -31,6 +29,6 @@ let
       ];
     };
 in
-if prev.version == 7
-then version7
-else throw "Unsupported flake.lock version ${prev.version}"
+  if prev.version == 7
+  then version7
+  else throw "Unsupported flake.lock version ${prev.version}"

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -66,10 +66,12 @@
           # inputOverrides = { };
         };
       in rec {
-        packages = flake-utils.lib.flattenTree ({
-            inherit emacs;
-          }
-          // nixpkgs.lib.getAttrs ["lock" "update"] (emacs.admin "lock"));
+        packages = flake-utils.lib.flattenTree {
+          inherit emacs;
+        };
+        apps = emacs.makeApps {
+          lockDirName = "lock";
+        };
         defaultPackage = packages.emacs;
       }
     );

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -30,15 +30,15 @@
     };
   };
 
-  outputs =
-    { self
-    , nixpkgs
-    , nixpkgs-emacs
-    , flake-utils
-    , ...
-    } @ inputs:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-emacs,
+    flake-utils,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
@@ -54,7 +54,7 @@
           ];
         };
 
-        emacs = (pkgs.emacsTwist {
+        emacs = pkgs.emacsTwist {
           emacsPackage = pkgsForEmacs.emacsUnstable.overrideAttrs (_: {
             version = "28.0.91";
           });
@@ -64,13 +64,13 @@
             ./init.el
           ];
           # inputOverrides = { };
-        });
-
+        };
       in rec {
         packages = flake-utils.lib.flattenTree ({
-          inherit emacs;
-        } // nixpkgs.lib.getAttrs [ "lock" "update" ] (emacs.admin "lock"));
+            inherit emacs;
+          }
+          // nixpkgs.lib.getAttrs ["lock" "update"] (emacs.admin "lock"));
         defaultPackage = packages.emacs;
       }
     );
-  }
+}

--- a/template/inventories.nix
+++ b/template/inventories.nix
@@ -1,5 +1,4 @@
-inputs:
-[
+inputs: [
   {
     type = "melpa";
     path = ./recipes;

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,11 +8,11 @@ build:
 .PHONY: build
 
 lock:
-	$(NIX) run .#admin.lock --impure -- $(NIX_OPTIONS)
+	$(NIX) run .#lock --impure $(NIX_OPTIONS)
 .PHONY: lock
 
 update:
-	$(NIX) run .#admin.update --impure -- $(NIX_OPTIONS)
+	$(NIX) run .#update --impure $(NIX_OPTIONS)
 .PHONY: update
 
 clean:

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -128,22 +128,6 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1646939531,
-        "narHash": "sha256-bxOjVqcsccCNm+jSmEh/bm0tqfE3SdjwS+p+FZja3ho=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fcd48a5a0693f016a5c370460d0c2a8243b882dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nongnu": {
       "flake": false,
       "locked": {
@@ -169,7 +153,6 @@
         "flake-utils": "flake-utils",
         "gnu-elpa": "gnu-elpa",
         "melpa": "melpa",
-        "nixpkgs": "nixpkgs",
         "nongnu": "nongnu",
         "twist": "twist"
       }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -120,7 +120,9 @@
     in {
       packages = {
         inherit emacs;
-        admin = emacs.admin "lock";
+      };
+      apps = emacs.makeApps {
+        lockDirName = "lock";
       };
       defaultPackage = emacs;
     });

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -41,14 +41,13 @@
   #   url = "github:nix-community/emacs-overlay";
   # };
 
-  outputs =
-    { flake-utils
-    , emacs-ci
-      # , emacs-unstable
-    , ...
-    } @ inputs:
-    flake-utils.lib.eachDefaultSystem (system:
-    let
+  outputs = {
+    flake-utils,
+    emacs-ci,
+    # , emacs-unstable
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system: let
       inherit (builtins) filter match elem;
 
       # Access niv sources of nix-emacs-ci
@@ -118,8 +117,7 @@
       };
 
       inherit (flake-utils.lib) mkApp;
-    in
-    {
+    in {
       packages = {
         inherit emacs;
         admin = emacs.admin "lock";

--- a/test/lock/archive.lock
+++ b/test/lock/archive.lock
@@ -1,9 +1,9 @@
 {
   "bbdb": {
     "archive": {
-      "narHash": "sha256-RpkvwNk/f5yZpPLk6rxAc5UMiQH7IdRXqNKE/O26Hf8=",
+      "narHash": "sha256-3kkU51Xd1nmPgAzwf4S95m6eZ9w15aLCDdVei6ZIJ7o=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.1.tar"
+      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.2.tar"
     },
     "inventory": {
       "type": "archive",
@@ -13,7 +13,7 @@
       "cl-lib": "0.5",
       "emacs": "24"
     },
-    "version": "3.2.2.1"
+    "version": "3.2.2.2"
   },
   "ivy": {
     "archive": {

--- a/test/lock/flake.lock
+++ b/test/lock/flake.lock
@@ -80,22 +80,6 @@
         "type": "github"
       }
     },
-    "forge": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1646939848,
-        "narHash": "sha256-zvbhwgcaFC3yVfC7kXT1wZKOBaib6gcMnJk0MhvYijQ=",
-        "owner": "magit",
-        "repo": "forge",
-        "rev": "bc99603b5a0cd5b3a5f209772b7f818d205b8a3f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "magit",
-        "repo": "forge",
-        "type": "github"
-      }
-    },
     "git-commit": {
       "flake": false,
       "locked": {
@@ -109,6 +93,22 @@
       "original": {
         "owner": "magit",
         "repo": "magit",
+        "type": "github"
+      }
+    },
+    "google-translate": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1617709095,
+        "narHash": "sha256-rvviaqVoigix3jd4ys2KN8nst//14tXn2/iz+46zP44=",
+        "owner": "atykhonov",
+        "repo": "google-translate",
+        "rev": "0f7f48a09bca064999ecea03102a7c96f52cbd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "atykhonov",
+        "repo": "google-translate",
         "type": "github"
       }
     },
@@ -160,6 +160,22 @@
         "type": "github"
       }
     },
+    "popup": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650468262,
+        "narHash": "sha256-nGoaA+EQ04oiOnygzA13AUWqAwJaqlZ1Ctkx+UbavdE=",
+        "owner": "auto-complete",
+        "repo": "popup-el",
+        "rev": "3bf430270c74dad830ab9d776aab23cbf3ea3953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "auto-complete",
+        "repo": "popup-el",
+        "type": "github"
+      }
+    },
     "queue": {
       "flake": false,
       "locked": {
@@ -183,11 +199,12 @@
         "consult": "consult",
         "dash": "dash",
         "doom-themes": "doom-themes",
-        "forge": "forge",
         "git-commit": "git-commit",
+        "google-translate": "google-translate",
         "magit": "magit",
         "magit-section": "magit-section",
         "org-transclusion": "org-transclusion",
+        "popup": "popup",
         "queue": "queue",
         "tramp": "tramp",
         "undo-browse": "undo-browse",

--- a/test/lock/flake.nix
+++ b/test/lock/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
+  description =
+    "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
   inputs = {
     async = {
       flake = false;
@@ -31,16 +32,16 @@
       repo = "themes";
       type = "github";
     };
-    forge = {
-      flake = false;
-      owner = "magit";
-      repo = "forge";
-      type = "github";
-    };
     git-commit = {
       flake = false;
       owner = "magit";
       repo = "magit";
+      type = "github";
+    };
+    google-translate = {
+      flake = false;
+      owner = "atykhonov";
+      repo = "google-translate";
       type = "github";
     };
     magit = {
@@ -59,6 +60,12 @@
       flake = false;
       owner = "nobiot";
       repo = "org-transclusion";
+      type = "github";
+    };
+    popup = {
+      flake = false;
+      owner = "auto-complete";
+      repo = "popup-el";
       type = "github";
     };
     queue = {
@@ -103,5 +110,5 @@
       type = "github";
     };
   };
-  outputs = {...}: {};
+  outputs = { ... }: { };
 }

--- a/test/lock/flake.nix
+++ b/test/lock/flake.nix
@@ -1,6 +1,5 @@
 {
-  description =
-    "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
+  description = "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
   inputs = {
     async = {
       flake = false;
@@ -104,5 +103,5 @@
       type = "github";
     };
   };
-  outputs = { ... }: { };
+  outputs = {...}: {};
 }


### PR DESCRIPTION
[Nix 2.8](https://discourse.nixos.org/t/nix-2-8-0-released/18714) has been released, and it precisely defines the format for [apps](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps).

Twist.nix has provided commands for administration as `lock` and `update` packages, but it would be better to provide them as apps. The APIs can change, so the user configuration for the commands should be as generic as possible. 