### PR TITLE
Improve handling of *-pkg.el file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "elisp-helpers": {
       "flake": false,
       "locked": {
-        "lastModified": 1644084222,
-        "narHash": "sha256-Z7K0UkMvjZ+rwzhE2smK5GCl4LkrmY97MKkpay23yDo=",
+        "lastModified": 1650556836,
+        "narHash": "sha256-i3182w+0B/GZvnViDfvCEl+VDPPtGt0XQtTCaEaISm4=",
         "owner": "emacs-twist",
         "repo": "elisp-helpers",
-        "rev": "7e295072ec385d0ef7e46efca259d9276542cd6f",
+        "rev": "fb8e8f69253bbcfcd9b082c8a24d160464f8f722",
         "type": "github"
       },
       "original": {

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -39,15 +39,19 @@ in
       else self.src + "/${ename}-pkg.el";
     #  OPTIMIZE: Reduce filesystem access
     hasPkgFile =
-      ! (self.ignorePkgFile or false)
-      && (length pkgFiles
-        != 0
-        || pathExists pkgFile);
+      length pkgFiles
+      != 0
+      || pathExists pkgFile;
     packageDesc =
       # If the package description does not specify dependencies,
       # packageRequires attribute will be null, so remove the attribute.
       if hasPkgFile
-      then lib.filterAttrs (_: v: v != null) (lib.parsePkg (readFile pkgFile))
+      then
+        lib.warnIf (self ? ignorePkgFile) "ignorePkgFile is obsolete and does not take effect."
+        (
+          lib.filterAttrs (_: v: v != null)
+          (lib.parsePkg (readFile pkgFile))
+        )
       else {};
 
     # builtins.readFile fails when the source file contains control characters.

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -108,21 +108,21 @@ in
       # TODO: Check https://github.com/melpa/melpa/issues/2955 on the right versioning scheme
       version =
         attrs.version
-        or packageDesc.version
         or headers.Version
         or headers.Package-Version
+        or packageDesc.version
         # There are packages that lack a version header, so fallback to zero.
         or "0.0.0";
 
       author = headers.Author or null;
 
       meta =
-        (import ./headers-to-meta.nix {
+        (lib.optionalAttrs hasPkgFile {
+          description = packageDesc.summary;
+        })
+        // (import ./headers-to-meta.nix {
           inherit lib;
           inherit (self) headers;
-        })
-        // (lib.optionalAttrs hasPkgFile {
-          description = packageDesc.summary;
         });
 
       packageRequires =

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -44,8 +44,10 @@ in
         != 0
         || pathExists pkgFile);
     packageDesc =
+      # If the package description does not specify dependencies,
+      # packageRequires attribute will be null, so remove the attribute.
       if hasPkgFile
-      then lib.parsePkg (readFile pkgFile)
+      then lib.filterAttrs (_: v: v != null) (lib.parsePkg (readFile pkgFile))
       else {};
 
     # builtins.readFile fails when the source file contains control characters.

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -3,11 +3,11 @@
     "elisp-helpers": {
       "flake": false,
       "locked": {
-        "lastModified": 1644084222,
-        "narHash": "sha256-Z7K0UkMvjZ+rwzhE2smK5GCl4LkrmY97MKkpay23yDo=",
+        "lastModified": 1650556836,
+        "narHash": "sha256-i3182w+0B/GZvnViDfvCEl+VDPPtGt0XQtTCaEaISm4=",
         "owner": "emacs-twist",
         "repo": "elisp-helpers",
-        "rev": "7e295072ec385d0ef7e46efca259d9276542cd6f",
+        "rev": "fb8e8f69253bbcfcd9b082c8a24d160464f8f722",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     "fromElisp": {
       "flake": false,
       "locked": {
-        "lastModified": 1620725665,
-        "narHash": "sha256-xLQDuSXjlTJUPftbT/PTegrn6yySoEYrFlUP5e8Kfuc=",
+        "lastModified": 1649625973,
+        "narHash": "sha256-y/7IsibjBGY3uUN9K/VMKPTVAbgsV0Xdi8Hnv6Nq76E=",
         "owner": "talyz",
         "repo": "fromElisp",
-        "rev": "1c0d9b629b505a6d7ba050172b2fcaf43fa32801",
+        "rev": "edd1301d1fc35440ae6c918ca92039233e3d770f",
         "type": "github"
       },
       "original": {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -113,6 +113,10 @@
           google-translate = _: _: {
             ignorePkgFile = true;
           };
+          # This package contains a pkg file without the dependencies field
+          drag-stuff = _: _: {
+            ignorePkgFile = true;
+          };
         };
       };
 

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -107,16 +107,6 @@
               "bbdb-vm-aux.el"
             ];
           };
-          # google-translate currently contains an invalid pkg file, but it may
-          # be fixed later. See
-          # https://github.com/atykhonov/google-translate/pull/148
-          google-translate = _: _: {
-            ignorePkgFile = true;
-          };
-          # This package contains a pkg file without the dependencies field
-          drag-stuff = _: _: {
-            ignorePkgFile = true;
-          };
         };
       };
 

--- a/test/init.el
+++ b/test/init.el
@@ -57,3 +57,6 @@
 
 (use-package google-translate
   :ensure t)
+
+(use-package drag-stuff
+  :ensure t)


### PR DESCRIPTION
Package description files (`*-pkg.el`) of package.el have been a source of trouble. Some package repositories contain one, but they are often outdated or do not correctly specify dependencies. Package authors usually do not have to contain these files, because MELPA generates them, but the authors/maintainers of such packages are less likely to respond to PRs, because those packages tend to be old.

In this PR, the following changes will be made:

- For the package summary and version, prefer information from the library header. These information don't affect the build, but the version number from the package description can be inaccurate, so disregard them when possible.
- Allow package description files that do not specify dependencies. This is supported at emacs-twist/elisp-helpers#28, but twist.nix requires a workaround. If the package description specifies a non-empty list of dependencies, it will be used. Otherwise, the dependencies from `Package-Requires` header will be used, if any.
- Drop `ignorePkgFile` option for individual package metadata. This is likely to be unnecessary.