### PR TITLE
Set meta.mainProgram for nix run support

### DIFF
--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -54,8 +54,8 @@ in
     buildInputs = [lndir texinfo];
     propagatedBuildInputs = [emacs packageEnv] ++ executablePackages;
     nativeBuildInputs = [makeWrapper];
-    # Useful for use with flake-utils.lib.mkApp
-    passthru.exePath = "/bin/emacs";
+    # Support for nix run
+    meta.mainProgram = "emacs";
 
     passAsFile = ["subdirs" "siteStartExtra"];
 


### PR DESCRIPTION
This is the proper way to support `nix run` now. See https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps