### PR TITLE
ci: Fix the PR check

### DIFF
--- a/.github/workflows/update-inputs.yml
+++ b/.github/workflows/update-inputs.yml
@@ -9,7 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     outputs:
-      updated: ${{ steps.pr.conclusion == 'success' }}
+      pr: ${{ steps.pr.outputs.pull-request-operation }}
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v17
@@ -25,5 +25,5 @@ jobs:
 
   test:
     needs: ['update']
-    if: ${{ needs.update.outputs.updated == 'true' }}
+    if: ${{ needs.update.outputs.pr == 'created' || needs.update.outputs.pr == 'updated' }}
     uses: ./.github/workflows/smoke-test.yml


### PR DESCRIPTION
The conclusion is success even if the `create-pull-request` action doesn't create a PR. A proper way would be to check [the output](https://github.com/peter-evans/create-pull-request#action-outputs) of the action.