### PR TITLE
Allow twist distributions to navigate Emacs C source code

### DIFF
--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -87,6 +87,9 @@ in
       ln -s ${emacs}/share/$dir $out/share/$dir
     done
 
+    mkdir -p $out/share/emacs
+    ln -s ${emacs}/share/emacs/${emacs.version} $out/share/emacs/${emacs.version}
+
     siteLisp=$out/share/emacs/site-lisp
     mkdir -p $siteLisp
     if [[ -e $subdirsPath ]]

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -78,10 +78,13 @@ in
     '';
   }
   ''
-    for dir in bin share/applications share/icons
+    mkdir -p $out/bin
+    lndir -silent ${emacs}/bin $out/bin
+
+    mkdir -p $out/share
+    for dir in applications icons
     do
-      mkdir -p $out/$dir
-      lndir -silent ${emacs}/$dir $out/$dir
+      ln -s ${emacs}/share/$dir $out/share/$dir
     done
 
     siteLisp=$out/share/emacs/site-lisp


### PR DESCRIPTION
Symlink the  `share/emacs/VERSION` directory, so `find-function-C-source-directory` is set to the right location. This will allow `describe-function` / `describe-variable` / etc. to navigate Emacs C source code.

 