### PR TITLE
Work around the preloaded native lisp directory

### DIFF
--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -117,6 +117,9 @@ in
     cd $siteLisp
     ${emacs}/bin/emacs --batch -f batch-byte-compile site-start.el
     ${lib.optionalString nativeComp ''
+      # Work around preloaded native lisp.
+      ln -t $out -s ${emacs}/lib/emacs/${emacs.version}/native-lisp
+
       nativeLisp=$out/share/emacs/native-lisp
       emacs --batch \
         --eval "(push \"$nativeLisp/\" native-comp-eln-load-path)" \


### PR DESCRIPTION
This is a workaround for #53. This is a bit ugly, as it produces `native-lisp` symlink under the toplevel directory of the output, but it works for now.

It would be better to change the invocation directory of Emacs according to how Emacs is supposed to start, but I can't find a way to do it elegantly.