### PR TITLE
fix: Correctly throw an error if revDep is null

### DIFF
--- a/pkgs/emacs/data/default.nix
+++ b/pkgs/emacs/data/default.nix
@@ -67,7 +67,12 @@ in
     packageData = foldl' (acc: {value, ...}: value // acc) {} inventoryPackageSets;
 
     findPrescription = revDep: ename:
-      packageData.${ename} or (throw "Package ${ename} required by ${revDep} is not found");
+      packageData.${ename}
+      or (
+        if revDep == null
+        then throw "Package ${ename} is not found"
+        else throw "Package ${ename} required by ${revDep} is not found"
+      );
 
     findFromPinned = revDep: ename: inventory:
       if hasAttr ename inventory


### PR DESCRIPTION
revDep is null if no package depends on it in the config.