### PR TITLE
Parse with file name rather than file contents

### DIFF
--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -8,6 +8,7 @@
   inventories,
   initFiles,
   initParser ? lib.parseUsePackages {},
+  initReader ? file: initParser (builtins.readFile file),
   extraPackages ? ["use-package"],
   addSystemPackages ? true,
   inputOverrides ? {},
@@ -40,7 +41,7 @@ in
     archiveLockFile = lockDir + "/archive.lock";
 
     userConfig = lib.pipe self.initFiles [
-      (map (file: initParser (readFile file)))
+      (map initReader)
       lib.zipAttrs
       (lib.mapAttrs (
         name: values:


### PR DESCRIPTION
I modified this repo for my own use-case, but it's a very small change and I
think it's a generally useful one. Specifically, I'm trying to wrap DOOM Emacs
in Nix, by replacing straight.el. DOOM configs have 3 files, and each has its
meaning, it's not just package definitions, and package related pieces may come
in a few different forms (builtin DOOM modules vs. user packages).

With the version prior, only the contents of each file in `initFiles` was passed
to `initParser`, which made per-file behavior much harder to implement. By
reading inside the parser with the name as argument, this becomes easier.

I also added a direnv shell with rnix-lsp, you can safely cherry-pick that one
out if it isn't desired.

I thought this could help others, but if you think it won't, no worries, I'l try
and maintain my changes separately.

## Testing

I couldn't quite figure out how this is tested, what I ended up doing was
building the test folder's `flake.nix` and running the generated emacs
environment. That worked well, but it might not be sufficient to guarantee
accuracy.