### PR TITLE
Trace impure inputs for ease of debugging

### DIFF
--- a/pkgs/emacs/data/inventory/elpa.nix
+++ b/pkgs/emacs/data/inventory/elpa.nix
@@ -85,7 +85,9 @@ with builtins;
           src =
             if hasAttr ename flakeLockData
             then fetchTree flakeLockData.${ename}
-            else fetchTree self.origin;
+            else
+              trace "Impure input for package ${ename} (in elpa.nix): ${toJSON self.origin}"
+              (fetchTree self.origin);
           origin = lib.flakeRefAttrsFromElpaAttrs {preferReleaseBranch = true;} entry;
           inventory = inventory // {inherit entry;};
 

--- a/pkgs/emacs/data/inventory/gitmodules.nix
+++ b/pkgs/emacs/data/inventory/gitmodules.nix
@@ -9,7 +9,9 @@ with builtins;
         src =
           if hasAttr ename flakeLockData
           then fetchTree flakeLockData.${ename}
-          else fetchTree self.origin;
+          else
+            trace "Impure input for package ${ename} (in gitmodules.nix): ${toJSON self.origin}"
+            (fetchTree self.origin);
         doTangle = false;
         files = lib.expandMelpaRecipeFiles self.src null;
         inherit origin;

--- a/pkgs/emacs/data/inventory/melpa.nix
+++ b/pkgs/emacs/data/inventory/melpa.nix
@@ -7,7 +7,9 @@ with builtins; let
     src =
       if hasAttr ename flakeLockData
       then fetchTree flakeLockData.${ename}
-      else fetchTree self.origin;
+      else
+        trace "Impure input for package ${ename} (in melpa.nix): ${toJSON self.origin}"
+        (fetchTree self.origin);
     doTangle = true;
     files = lib.expandMelpaRecipeFiles self.src (entry.files or null);
     origin = lib.flakeRefAttrsFromMelpaRecipe entry;


### PR DESCRIPTION
Missing lock entries often cause a build failure, but it required an extra step of investigation. Printing the name of a package that demands an impure input may help the issue. The message will not be printed if the build is entirely pure.