### PR TITLE
Switch to https URL in emacsmirror

### DIFF
--- a/pkgs/build-support/gitUrlToAttrs.nix
+++ b/pkgs/build-support/gitUrlToAttrs.nix
@@ -1,6 +1,6 @@
 s:
 with builtins; let
-  githubMatch = match "git@github.com:(.+)/(.+)\.git" s;
+  githubMatch = match "https://github.com/(.+)/(.+?)" s;
 in
   if githubMatch != null
   then {

--- a/pkgs/build-support/testGitUrlToAttrs.nix
+++ b/pkgs/build-support/testGitUrlToAttrs.nix
@@ -1,0 +1,15 @@
+with builtins; let
+  pkgs = import <nixpkgs> {};
+
+  gitUrlToAttrs = import ./gitUrlToAttrs.nix;
+in
+  pkgs.lib.runTests {
+    testParse = {
+      expr = gitUrlToAttrs "https://github.com/emacsmirror/2048-game";
+      expected = {
+        type = "github";
+        owner = "emacsmirror";
+        repo = "2048-game";
+      };
+    };
+  }


### PR DESCRIPTION
EmacsMirror <https://github.com/emacsmirror/epkgs/blob/master/.gitmodules> has switched to https URL at
https://github.com/emacsmirror/epkgs/commit/25d4170666631085e3e14ddc779893d177372233.