### PR TITLE
Take Core ELPA source for testing from the Emacs binary source

### DIFF
--- a/test/flake.lock
+++ b/test/flake.lock
@@ -16,22 +16,6 @@
         "type": "github"
       }
     },
-    "emacs": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1670072772,
-        "narHash": "sha256-mxheQF+yXfEDz9G6y1jjuDnXpZIMTvGeA30Dp68qimA=",
-        "owner": "emacs-mirror",
-        "repo": "emacs",
-        "rev": "1c9013865183f0ea21218602917b5c16ecef465d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emacs-mirror",
-        "repo": "emacs",
-        "type": "github"
-      }
-    },
     "emacs-ci": {
       "flake": false,
       "locked": {
@@ -147,7 +131,6 @@
     },
     "root": {
       "inputs": {
-        "emacs": "emacs",
         "emacs-ci": "emacs-ci",
         "epkgs": "epkgs",
         "flake-utils": "flake-utils",

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -24,11 +24,6 @@
     flake = false;
   };
 
-  inputs.emacs = {
-    url = "github:emacs-mirror/emacs";
-    flake = false;
-  };
-
   inputs.emacs-ci = {
     url = "github:purcell/nix-emacs-ci";
     flake = false;
@@ -79,7 +74,7 @@
           {
             type = "elpa";
             path = inputs.gnu-elpa.outPath + "/elpa-packages";
-            core-src = inputs.emacs.outPath;
+            core-src = pkgs.emacs-snapshot.src;
             auto-sync-only = true;
           }
           {


### PR DESCRIPTION
For smaller lock files and smaller download size. The source files of the Emacs executable is required any way for builtins libraries (which may be cached in the future).

This is an inspiration from Terje Larsen's repository: https://github.com/terlar/emacs-config