### PR TITLE
Fix derivation options of the elisp builder

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,9 +19,7 @@ jobs:
 
     - uses: cachix/cachix-action@v12
       with:
-        name: akirak
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-        extraPullNames: emacs-ci
+        name: emacs-ci
 
     - name: Update the flake inputs for the test
       run: nix flake update --inputs-from $PWD/.. --override-input twist $PWD/..

--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -47,8 +47,6 @@ in
       (lib.toPName ename)
     ];
 
-    allowSubstitutes = false;
-
     outputs =
       ["out"]
       ++ lib.optional (wantExtraOutputs && canProduceInfo) "info";

--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -47,7 +47,6 @@ in
       (lib.toPName ename)
     ];
 
-    preferLocalBuild = true;
     allowSubstitutes = false;
 
     outputs =


### PR DESCRIPTION
This will allow substitution of Emacs Lisp packages using binary cache. 
