### PR TITLE
Work around corner cases in the dependency check

### DIFF
--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -7,7 +7,7 @@
 }: {
   ename,
   src,
-  version,
+  version ? null,
   files,
   lispFiles,
   meta,
@@ -40,7 +40,9 @@ with builtins; let
     files);
 in
   stdenv.mkDerivation {
-    inherit src ename meta version;
+    inherit src ename meta;
+    # Add a fake version if the version is null
+    version = if version == null then "0.0.0" else version;
 
     pname = concatStringsSep "-" [
       (replaceStrings ["."] ["-"] emacs.name)

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -127,8 +127,8 @@ in
         or headers.Version
         or headers.Package-Version
         or packageDesc.version
-        # There are packages that lack a version header, so fallback to zero.
-        or "0.0.0";
+        # Set a null version if the package lacks a version header.
+        or null;
 
       author = headers.Author or null;
 

--- a/pkgs/emacs/tools/check-versions.nix
+++ b/pkgs/emacs/tools/check-versions.nix
@@ -66,7 +66,16 @@
         required
         == null
         || actual == "builtin"
-        || compareVersions isDateVersion actual required;
+        || (
+          if actual == null
+          # There are packages that seem to have removed a version header. In
+          # that case, there are dependants that have a version requirement,
+          # while their dependency actually have no version. It is impossible
+          # to compare the versions in this case. I don't know if I can simply
+          # ignore this case, so I will display a warning for now.
+          then lib.warn "Package ${ename} has no version header" true
+          else compareVersions isDateVersion actual required
+        );
     } ["isDateVersion"];
 
   filterErrors = lib.filterAttrs (_: {satisfied, ...}: !satisfied);

--- a/pkgs/emacs/tools/check-versions.nix
+++ b/pkgs/emacs/tools/check-versions.nix
@@ -28,6 +28,8 @@
   inputVersion = isDate: attrs:
     if isDate
     then srcDateString attrs.src
+    else if ! attrs ? version
+    then null
     # Some packages have a version suffixed with "-pre", and there are
     # packages that depend on the version with the suffix removed. For
     # example, envrc depends on inheritenv 0.1, while the latest version of

--- a/pkgs/emacs/tools/check-versions.nix
+++ b/pkgs/emacs/tools/check-versions.nix
@@ -28,7 +28,14 @@
   inputVersion = isDate: attrs:
     if isDate
     then srcDateString attrs.src
-    else attrs.version;
+    # Some packages have a version suffixed with "-pre", and there are
+    # packages that depend on the version with the suffix removed. For
+    # example, envrc depends on inheritenv 0.1, while the latest version of
+    # inheritenv is 0.1-pre at present. In this case, we will consider that
+    # envrc depends on a pre-release version of the package, which should work
+    # once the version is officially released. Thus, we can strip "-pre"
+    # suffix.
+    else lib.removeSuffix "-pre" attrs.version;
 
   compareVersions = isDate: actual: required:
     if isDate


### PR DESCRIPTION
`nix build .#emacs-config.depsCheck` checks package versions specified in headers, but there were some cases where the comparison raised a false positive. This PR will fix those cases.