### PR TITLE
Add a home-manager module

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -103,4 +103,14 @@ jobs:
         nix build .#checks.${{ steps.system.outputs.system }}.symlink
       working-directory: test
 
+    - name: Build home-manager configuration
+      run: |
+        nix build .#homeConfigurations.${{ steps.system.outputs.system }}.activationPackage
+        test -f result/home-files/.local/share/emacs/init.el
+        test -f result/home-files/.local/share/emacs/early-init.el
+        test -x result/home-path/bin/emacsclient
+        test -x result/home-path/bin/my-emacs
+        result/home-path/bin/my-emacs -batch -l consult
+      working-directory: test
+
     - run: nix flake show

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
     overlays = {
       default = import ./pkgs inputs;
     };
+    homeModules = {
+      emacs-twist = ./modules/home-manager.nix;
+    };
     templates = {
       default = {
         description = "A basic configuration for use-package";

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -52,6 +52,12 @@ in {
         example = ".local/share/emacs";
       };
 
+      createInitFile = mkOption {
+        type = types.bool;
+        description = "Whether to create init.el in the directory";
+        default = false;
+      };
+
       earlyInitFile = mkOption {
         type = types.nullOr types.path;
         description = ''
@@ -83,14 +89,12 @@ in {
     home.packages = [wrapper] ++ lib.optional cfg.emacsclient.enable emacsclient;
 
     home.file = builtins.listToAttrs (
-      [
-        {
-          name = "${cfg.directory}/init.el";
-          value = {
-            source = "${initFile}/init.el";
-          };
-        }
-      ]
+      (lib.optional cfg.createInitFile {
+        name = "${cfg.directory}/init.el";
+        value = {
+          source = "${initFile}/init.el";
+        };
+      })
       ++ (lib.optional (cfg.earlyInitFile != null) {
         name = "${cfg.directory}/early-init.el";
         value = {

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,4 +1,6 @@
-/* home-manager module that provides an installation of Emacs */
+/*
+home-manager module that provides an installation of Emacs
+*/
 {
   config,
   lib,
@@ -51,8 +53,13 @@ in {
       };
 
       earlyInitFile = mkOption {
-        type = types.path;
-        description = "Path to early-init.el";
+        type = types.nullOr types.path;
+        description = ''
+          Path to early-init.el.
+
+          If the value is nil, no file is created in the directory.
+        '';
+        default = null;
       };
 
       config = mkOption {
@@ -75,7 +82,21 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = [wrapper] ++ lib.optional cfg.emacsclient.enable emacsclient;
 
-    home.file."${cfg.directory}/early-init.el".source = cfg.earlyInitFile;
-    home.file."${cfg.directory}/init.el".source = "${initFile}/init.el";
+    home.file = builtins.listToAttrs (
+      [
+        {
+          name = "${cfg.directory}/init.el";
+          value = {
+            source = "${initFile}/init.el";
+          };
+        }
+      ]
+      ++ (lib.optional (cfg.earlyInitFile != null) {
+        name = "${cfg.directory}/early-init.el";
+        value = {
+          source = cfg.earlyInitFile;
+        };
+      })
+    );
   };
 }

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -96,6 +96,25 @@
         "url": "https://git.savannah.gnu.org/git/emacs/elpa.git"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1675247113,
+        "narHash": "sha256-+YcXjfCP4hNu8A68b/UoXFCTDwKLuLV+x/7dQnM5U/o=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "782cb855b2f23c485011a196c593e2d7e4fce746",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "melpa": {
       "flake": false,
       "locked": {
@@ -109,6 +128,22 @@
       "original": {
         "owner": "melpa",
         "repo": "melpa",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -135,6 +170,7 @@
         "epkgs": "epkgs",
         "flake-utils": "flake-utils",
         "gnu-elpa": "gnu-elpa",
+        "home-manager": "home-manager",
         "melpa": "melpa",
         "nongnu": "nongnu",
         "twist": "twist"
@@ -156,6 +192,21 @@
       "original": {
         "owner": "emacs-twist",
         "repo": "twist.nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -32,6 +32,10 @@
     flake = false;
   };
 
+  inputs.home-manager = {
+    url = "github:nix-community/home-manager";
+  };
+
   # You could use one of the Emacs builds from emacs-overlay,
   # but I wouldn't use it on CI.
   #
@@ -150,6 +154,30 @@
         lockDirName = "lock";
       };
       defaultPackage = emacs;
+      homeConfigurations = inputs.home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [
+          inputs.twist.homeModules.emacs-twist
+          {
+            home = {
+              stateVersion = "22.11";
+              # fake data
+              username = "user";
+              homeDirectory = "/home/user";
+            };
+            # Prevent build error
+            manual.manpages.enable = false;
+            programs.emacs-twist = {
+              enable = true;
+              name = "my-emacs";
+              emacsclient.enable = true;
+              directory = ".local/share/emacs";
+              earlyInitFile = ./early-init.el;
+              config = emacs;
+            };
+          }
+        ];
+      };
       checks = {
         symlink = pkgs.stdenv.mkDerivation {
           name = "emacs-twist-wrapper-test";

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -1,47 +1,36 @@
 {
-  description = "";
-
-  nixConfig.extra-substituters = "https://emacs-ci.cachix.org";
-  nixConfig.extra-trusted-public-keys = "emacs-ci.cachix.org-1:B5FVOrxhXXrOL0S+tQ7USrhjMT5iOPH+QN9q0NItom4=";
-
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-
-  inputs.twist = {
-    url = "github:emacs-twist/twist.nix";
+  nixConfig = {
+    extra-substituters = "https://emacs-ci.cachix.org";
+    extra-trusted-public-keys = "emacs-ci.cachix.org-1:B5FVOrxhXXrOL0S+tQ7USrhjMT5iOPH+QN9q0NItom4=";
   };
 
-  inputs.melpa = {
-    url = "github:melpa/melpa";
-    flake = false;
-  };
-  inputs.gnu-elpa = {
-    url = "git+https://git.savannah.gnu.org/git/emacs/elpa.git?ref=main";
-    flake = false;
-  };
-  inputs.nongnu = {
-    url = "git+https://git.savannah.gnu.org/git/emacs/nongnu.git?ref=main";
-    flake = false;
-  };
-  inputs.epkgs = {
-    url = "github:emacsmirror/epkgs";
-    flake = false;
-  };
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    twist.url = "github:emacs-twist/twist.nix";
+    home-manager.url = "github:nix-community/home-manager";
 
-  inputs.emacs-ci = {
-    url = "github:purcell/nix-emacs-ci";
-    flake = false;
-  };
+    melpa = {
+      url = "github:melpa/melpa";
+      flake = false;
+    };
+    gnu-elpa = {
+      url = "git+https://git.savannah.gnu.org/git/emacs/elpa.git?ref=main";
+      flake = false;
+    };
+    nongnu = {
+      url = "git+https://git.savannah.gnu.org/git/emacs/nongnu.git?ref=main";
+      flake = false;
+    };
+    epkgs = {
+      url = "github:emacsmirror/epkgs";
+      flake = false;
+    };
 
-  inputs.home-manager = {
-    url = "github:nix-community/home-manager";
+    emacs-ci = {
+      url = "github:purcell/nix-emacs-ci";
+      flake = false;
+    };
   };
-
-  # You could use one of the Emacs builds from emacs-overlay,
-  # but I wouldn't use it on CI.
-  #
-  # inputs.emacs-unstable = {
-  #   url = "github:nix-community/emacs-overlay";
-  # };
 
   outputs = {
     flake-utils,
@@ -53,9 +42,12 @@
       inherit (builtins) filter match elem;
 
       # Access niv sources of nix-emacs-ci
-      inherit (import (inputs.emacs-ci + "/nix/sources.nix") {
-        inherit system;
-      }) nixpkgs;
+      inherit
+        (import (inputs.emacs-ci + "/nix/sources.nix") {
+          inherit system;
+        })
+        nixpkgs
+        ;
 
       pkgs = import nixpkgs {
         inherit system;
@@ -68,82 +60,14 @@
 
       inherit (pkgs) lib;
 
-      emacs = pkgs.emacsTwist {
-        # Use nix-emacs-ci which is more lightweight than a regular build
-        emacsPackage = pkgs.emacs-snapshot;
-        # In an actual configuration, you would use this:
-        # emacs = pkgs.emacsPgtkGcc.overrideAttrs (_: { version = "29.0.50"; });
-        initFiles = [
-          ./init.el
-        ];
-        lockDir = ./lock;
-        inventories = [
-          {
-            type = "elpa";
-            path = inputs.gnu-elpa.outPath + "/elpa-packages";
-            core-src = pkgs.emacs-snapshot.src;
-            auto-sync-only = true;
-          }
-          {
-            name = "melpa";
-            type = "melpa";
-            path = inputs.melpa.outPath + "/recipes";
-          }
-          {
-            type = "elpa";
-            path = inputs.nongnu.outPath + "/elpa-packages";
-          }
-          {
-            name = "gnu";
-            type = "archive";
-            url = "https://elpa.gnu.org/packages/";
-          }
-          {
-            name = "emacsmirror";
-            type = "gitmodules";
-            path = inputs.epkgs.outPath + "/.gitmodules";
-          }
-        ];
-        inputOverrides = {
-          bbdb = _: super: {
-            files = builtins.removeAttrs super.files [
-              "bbdb-vm.el"
-              "bbdb-vm-aux.el"
-            ];
-          };
-        };
-      };
+      emacs = pkgs.callPackage ./twist.nix { inherit inputs; };
 
       # Another test path to build the whole derivation (not with --dry-run).
-      emacs-wrapper = pkgs.emacsTwist {
-        emacsPackage = pkgs.emacs-28-2.overrideAttrs (_: {version = "20221201.0";});
-        initFiles = [];
-        lockDir = ./lock;
-        inventories = [];
-      };
+      emacs-wrapper = pkgs.callPackage ./twist-minimal.nix { };
 
       # This is an example of interactive Emacs session.
       # You can start Emacs by running `nix run .#emacs-interactive`.
-      emacs-interactive = pkgs.writeShellApplication {
-        name = "emacs-interactive";
-
-        runtimeInputs = [
-          emacs
-        ];
-
-        text = ''
-          tmpdir=$(mktemp -d twist-test-XXX)
-          cleanup() {
-            echo "Clean up"
-            rm -rf "$tmpdir"
-          }
-          trap cleanup EXIT ERR
-          [[ -f init.el ]] && [[ -f early-init.el ]]
-          cp init.el early-init.el "$tmpdir"
-          echo "The init directory is $tmpdir"
-          emacs --init-directory="$tmpdir" "$@"
-        '';
-      };
+      emacs-interactive = pkgs.callPackage ./interactive.nix { inherit emacs; };
 
       inherit (flake-utils.lib) mkApp;
     in {
@@ -154,29 +78,8 @@
         lockDirName = "lock";
       };
       defaultPackage = emacs;
-      homeConfigurations = inputs.home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
-        modules = [
-          inputs.twist.homeModules.emacs-twist
-          {
-            home = {
-              stateVersion = "22.11";
-              # fake data
-              username = "user";
-              homeDirectory = "/home/user";
-            };
-            # Prevent build error
-            manual.manpages.enable = false;
-            programs.emacs-twist = {
-              enable = true;
-              name = "my-emacs";
-              emacsclient.enable = true;
-              directory = ".local/share/emacs";
-              earlyInitFile = ./early-init.el;
-              config = emacs;
-            };
-          }
-        ];
+      homeConfigurations = import ./home.nix {
+        inherit inputs emacs pkgs;
       };
       checks = {
         symlink = pkgs.stdenv.mkDerivation {

--- a/test/home.nix
+++ b/test/home.nix
@@ -1,0 +1,29 @@
+{
+  inputs,
+  emacs,
+  pkgs,
+}:
+inputs.home-manager.lib.homeManagerConfiguration {
+  inherit pkgs;
+  modules = [
+    inputs.twist.homeModules.emacs-twist
+    {
+      home = {
+        stateVersion = "22.11";
+        # fake data
+        username = "user";
+        homeDirectory = "/home/user";
+      };
+      # Prevent build error
+      manual.manpages.enable = false;
+      programs.emacs-twist = {
+        enable = true;
+        name = "my-emacs";
+        emacsclient.enable = true;
+        directory = ".local/share/emacs";
+        earlyInitFile = ./early-init.el;
+        config = emacs;
+      };
+    }
+  ];
+}

--- a/test/home.nix
+++ b/test/home.nix
@@ -22,6 +22,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
         name = "my-emacs";
         emacsclient.enable = true;
         directory = ".local/share/emacs";
+        createInitFile = true;
         earlyInitFile = ./early-init.el;
         config = emacs;
       };

--- a/test/home.nix
+++ b/test/home.nix
@@ -2,9 +2,10 @@
   inputs,
   emacs,
   pkgs,
+  lib,
 }:
 inputs.home-manager.lib.homeManagerConfiguration {
-  inherit pkgs;
+  inherit pkgs lib;
   modules = [
     inputs.twist.homeModules.emacs-twist
     {

--- a/test/interactive.nix
+++ b/test/interactive.nix
@@ -1,0 +1,24 @@
+{
+  writeShellApplication,
+  emacs,
+}:
+writeShellApplication {
+  name = "emacs-interactive";
+
+  runtimeInputs = [
+    emacs
+  ];
+
+  text = ''
+    tmpdir=$(mktemp -d twist-test-XXX)
+    cleanup() {
+      echo "Clean up"
+      rm -rf "$tmpdir"
+    }
+    trap cleanup EXIT ERR
+    [[ -f init.el ]] && [[ -f early-init.el ]]
+    cp init.el early-init.el "$tmpdir"
+    echo "The init directory is $tmpdir"
+    emacs --init-directory="$tmpdir" "$@"
+  '';
+}

--- a/test/twist-minimal.nix
+++ b/test/twist-minimal.nix
@@ -1,0 +1,10 @@
+{
+  emacsTwist,
+  emacs-28-2,
+}:
+emacsTwist {
+  emacsPackage = emacs-28-2.overrideAttrs (_: {version = "20221201.0";});
+  initFiles = [];
+  lockDir = ./lock;
+  inventories = [];
+}

--- a/test/twist.nix
+++ b/test/twist.nix
@@ -1,0 +1,50 @@
+{
+  emacsTwist,
+  emacs-snapshot,
+  inputs,
+}:
+emacsTwist {
+  # Use nix-emacs-ci which is more lightweight than a regular build
+  emacsPackage = emacs-snapshot;
+  # In an actual configuration, you would use this:
+  # emacs = pkgs.emacsPgtkGcc.overrideAttrs (_: { version = "29.0.50"; });
+  initFiles = [
+    ./init.el
+  ];
+  lockDir = ./lock;
+  inventories = [
+    {
+      type = "elpa";
+      path = inputs.gnu-elpa.outPath + "/elpa-packages";
+      core-src = emacs-snapshot.src;
+      auto-sync-only = true;
+    }
+    {
+      name = "melpa";
+      type = "melpa";
+      path = inputs.melpa.outPath + "/recipes";
+    }
+    {
+      type = "elpa";
+      path = inputs.nongnu.outPath + "/elpa-packages";
+    }
+    {
+      name = "gnu";
+      type = "archive";
+      url = "https://elpa.gnu.org/packages/";
+    }
+    {
+      name = "emacsmirror";
+      type = "gitmodules";
+      path = inputs.epkgs.outPath + "/.gitmodules";
+    }
+  ];
+  inputOverrides = {
+    bbdb = _: super: {
+      files = builtins.removeAttrs super.files [
+        "bbdb-vm.el"
+        "bbdb-vm-aux.el"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Thanks to `--init-directory` added to Emacs 29, it is now possible to configure a profile concisely using home-manager. You can use any directory as `user-emacs-directory` and home-manager generates `init.el` and `early-init.el` in the directory.