### PR TITLE
Initial support for hot reloading of Emacs Lisp packages

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'flake.lock'
     - 'pkgs/**'
+    - 'modules/**'
     - 'test/**'
     - '.github/workflows/smoke-test.yml'
   workflow_dispatch:

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -90,18 +90,20 @@ in {
         default = null;
       };
 
-      manifestFile = mkOption {
-        type = types.nullOr types.str;
+      createManifestFile = mkOption {
+        type = types.bool;
+        description = "Whether to create the manifest file in the directory";
+        default = false;
+      };
+
+      manifestFileName = mkOption {
+        type = types.str;
         description = lib.mdDoc ''
           Name of the manifest file, relative from `user-emacs-directory.
 
           This is necessary to enable hot reloading of packages.
         '';
-        example = "twist-manifesto.json";
-        default =
-          if emacs-config.emacsWrapper.elispManifestPath !=null
-          then "twist-manifest.json"
-          else null;
+        default = "twist-manifest.json";
       };
 
       config = mkOption {
@@ -180,12 +182,15 @@ in {
           source = cfg.earlyInitFile;
         };
       })
-      ++ (lib.optional (cfg.manifestFile != null) {
-        name = "${cfg.directory}/${cfg.manifestFile}";
-        value = {
-          source = emacs-config.emacsWrapper.elispManifestPath;
-        };
-      })
+      ++ (lib.optional (
+          cfg.createManifestFile
+          && emacs-config.emacsWrapper.elispManifestPath != null
+        ) {
+          name = "${cfg.directory}/${cfg.manifestFileName}";
+          value = {
+            source = emacs-config.emacsWrapper.elispManifestPath;
+          };
+        })
     );
 
     services.emacs = lib.mkIf cfg.serviceIntegration.enable {

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -88,6 +88,13 @@ in {
         };
       };
 
+      wrapper = mkOption {
+        type = types.package;
+        description = "The wrapper derivation";
+        readOnly = true;
+        default = wrapper;
+      };
+
       emacsclient = {
         enable = mkOption {
           type = types.bool;

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -189,17 +189,5 @@ in {
       enable = true;
       package = wrapper;
     };
-
-    systemd.user.services.emacs = lib.mkIf (cfg.serviceIntegration.enable
-      && pkgs.stdenv.isLinux) {
-      Service = {
-        ExecReload = "${wrapper}/bin/emacsclient --eval '(twist-push-digest \"${
-          emacs-config.emacsWrapper.elispEnvStatePath
-        }\"${
-          lib.optionalString (configurationRevision != null)
-          " \"${configurationRevision}\""
-        })'";
-      };
-    };
   };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -110,6 +110,12 @@ in {
         };
       };
 
+      serviceIntegration = {
+        enable = mkEnableOption (lib.mdDoc ''
+          Enable service integration. For now, only systemd is supported.
+        '');
+      };
+
       icons = {
         enable = mkOption {
           type = types.bool;
@@ -159,5 +165,19 @@ in {
         };
       })
     );
+
+    services.emacs = lib.mkIf cfg.serviceIntegration.enable {
+      enable = true;
+      package = wrapper;
+    };
+
+    systemd.user.services.emacs = lib.mkIf (cfg.serviceIntegration.enable
+      && pkgs.stdenv.isLinux) {
+      Service = {
+        ExecReload = "${wrapper}/bin/emacsclient --eval '(twist-push-digest \"${
+          emacs-config.emacsWrapper.elispEnvDigestPath
+        }\")'";
+      };
+    };
   };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -97,8 +97,11 @@ in {
 
           This is necessary to enable hot reloading of packages.
         '';
-        example = "twist.json";
-        default = null;
+        example = "twist-manifesto.json";
+        default =
+          if emacs-config.emacsWrapper.elispManifestPath !=null
+          then "twist-manifest.json"
+          else null;
       };
 
       config = mkOption {

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -90,6 +90,17 @@ in {
         default = null;
       };
 
+      stateFile = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc ''
+          Name of the state file, relative from `user-emacs-directory.
+
+          This is necessary to enable hot reloading of packages.
+        '';
+        example = "twist.json";
+        default = null;
+      };
+
       config = mkOption {
         type = mkOptionType {
           name = "twist";
@@ -166,6 +177,12 @@ in {
           source = cfg.earlyInitFile;
         };
       })
+      ++ (lib.optional (cfg.stateFile != null) {
+        name = "${cfg.directory}/${cfg.stateFile}";
+        value = {
+          source = emacs-config.emacsWrapper.elispEnvStatePath;
+        };
+      })
     );
 
     services.emacs = lib.mkIf cfg.serviceIntegration.enable {
@@ -177,7 +194,7 @@ in {
       && pkgs.stdenv.isLinux) {
       Service = {
         ExecReload = "${wrapper}/bin/emacsclient --eval '(twist-push-digest \"${
-          emacs-config.emacsWrapper.elispEnvDigestPath
+          emacs-config.emacsWrapper.elispEnvStatePath
         }\"${
           lib.optionalString (configurationRevision != null)
           " \"${configurationRevision}\""

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -12,6 +12,8 @@ home-manager module that provides an installation of Emacs
 
   emacs-config = cfg.config;
 
+  configurationRevision = emacs-config.configurationRevision;
+
   initFile = pkgs.runCommandLocal "init.el" {} ''
     mkdir -p $out
     touch $out/init.el
@@ -176,7 +178,10 @@ in {
       Service = {
         ExecReload = "${wrapper}/bin/emacsclient --eval '(twist-push-digest \"${
           emacs-config.emacsWrapper.elispEnvDigestPath
-        }\")'";
+        }\"${
+          lib.optionalString (configurationRevision != null)
+          " \"${configurationRevision}\""
+        })'";
       };
     };
   };

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -90,10 +90,10 @@ in {
         default = null;
       };
 
-      stateFile = mkOption {
+      manifestFile = mkOption {
         type = types.nullOr types.str;
         description = lib.mdDoc ''
-          Name of the state file, relative from `user-emacs-directory.
+          Name of the manifest file, relative from `user-emacs-directory.
 
           This is necessary to enable hot reloading of packages.
         '';
@@ -177,10 +177,10 @@ in {
           source = cfg.earlyInitFile;
         };
       })
-      ++ (lib.optional (cfg.stateFile != null) {
-        name = "${cfg.directory}/${cfg.stateFile}";
+      ++ (lib.optional (cfg.manifestFile != null) {
+        name = "${cfg.directory}/${cfg.manifestFile}";
         value = {
-          source = emacs-config.emacsWrapper.elispEnvStatePath;
+          source = emacs-config.emacsWrapper.elispManifestPath;
         };
       })
     );

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -140,7 +140,6 @@ in
 
     inherit builtinLibraryList;
     inherit depsCheck revDeps;
-    inherit configurationRevision;
 
     # An actual derivation set of Emacs Lisp packages. You can override this
     # attribute set to change how they are built.
@@ -173,7 +172,7 @@ in
       self.callPackage ./wrapper.nix
       {
         packageNames = attrNames packageInputs;
-        inherit extraOutputsToInstall exportState;
+        inherit extraOutputsToInstall exportState configurationRevision;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -24,6 +24,7 @@
   # Export a JSON digest of packages from the wrapper (experimental).
   # Needed if you use the hot-reloading feature of twist.el.
   exportDigest ? false,
+  configurationRevision ? null,
 }: let
   inherit
     (builtins)
@@ -139,6 +140,7 @@ in
 
     inherit builtinLibraryList;
     inherit depsCheck revDeps;
+    inherit configurationRevision;
 
     # An actual derivation set of Emacs Lisp packages. You can override this
     # attribute set to change how they are built.

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -21,9 +21,9 @@
     if wantExtraOutputs
     then ["info"]
     else [],
-  # Export a JSON digest of packages from the wrapper (experimental).
+  # Export a state file of of the package set from the wrapper (experimental).
   # Needed if you use the hot-reloading feature of twist.el.
-  exportDigest ? false,
+  exportState ? false,
   configurationRevision ? null,
 }: let
   inherit
@@ -173,7 +173,7 @@ in
       self.callPackage ./wrapper.nix
       {
         packageNames = attrNames packageInputs;
-        inherit extraOutputsToInstall exportDigest;
+        inherit extraOutputsToInstall exportState;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -21,6 +21,9 @@
     if wantExtraOutputs
     then ["info"]
     else [],
+  # Export a JSON digest of packages from the wrapper (experimental).
+  # Needed if you use the hot-reloading feature of twist.el.
+  exportDigest ? false,
 }: let
   inherit
     (builtins)
@@ -167,8 +170,8 @@ in
     emacsWrapper =
       self.callPackage ./wrapper.nix
       {
-        elispInputs = lib.attrVals (attrNames packageInputs) self.elispPackages;
-        inherit extraOutputsToInstall;
+        packageNames = attrNames packageInputs;
+        inherit extraOutputsToInstall exportDigest;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -21,9 +21,9 @@
     if wantExtraOutputs
     then ["info"]
     else [],
-  # Export a state file of of the package set from the wrapper (experimental).
-  # Needed if you use the hot-reloading feature of twist.el.
-  exportState ? false,
+  # Export a manifest file of of the package set from the wrapper
+  # (experimental). Needed if you use the hot-reloading feature of twist.el.
+  exportManifest ? false,
   configurationRevision ? null,
 }: let
   inherit
@@ -172,7 +172,7 @@ in
       self.callPackage ./wrapper.nix
       {
         packageNames = attrNames packageInputs;
-        inherit extraOutputsToInstall exportState configurationRevision;
+        inherit extraOutputsToInstall exportManifest configurationRevision;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -60,6 +60,7 @@
   infoPath = "${packageEnv}/share/info";
 
   elispEnvState = writeText "elisp-digest.json" (builtins.toJSON {
+    inherit configurationRevision;
     emacsPath = emacs.outPath;
     inherit nativeLoadPath infoPath;
     elispPackages = lib.genAttrs packageNames (

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -11,7 +11,7 @@
   elispPackages,
   executablePackages,
   extraOutputsToInstall,
-  exportDigest,
+  exportState,
   configurationRevision,
 }: let
   inherit (builtins) length listToAttrs;
@@ -59,7 +59,7 @@
 
   infoPath = "${packageEnv}/share/info";
 
-  elispEnvDigest = writeText "elisp-digest.json" (builtins.toJSON {
+  elispEnvState = writeText "elisp-digest.json" (builtins.toJSON {
     emacsPath = emacs.outPath;
     inherit nativeLoadPath infoPath;
     elispPackages = lib.genAttrs packageNames (
@@ -88,9 +88,9 @@ in
 
     siteStartExtra = ''
       (when init-file-user
-        ${lib.optionalString exportDigest ''
+        ${lib.optionalString exportState ''
         (defconst twist-running-emacs "${emacs.outPath}")
-        (defconst twist-current-digest-file "${elispEnvDigest}")
+        (defconst twist-current-digest-file "${elispEnvState}")
       ''}
         ${lib.optionalString (configurationRevision != null) ''
           (defvar twist-configuration-revision "${configurationRevision}")
@@ -103,9 +103,9 @@ in
       })
     '';
 
-    elispEnvDigestPath =
-      if exportDigest
-      then elispEnvDigest.outPath
+    elispEnvStatePath =
+      if exportState
+      then elispEnvState.outPath
       else "";
   }
   ''

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -12,6 +12,7 @@
   executablePackages,
   extraOutputsToInstall,
   exportDigest,
+  configurationRevision,
 }: let
   inherit (builtins) length listToAttrs;
 
@@ -91,6 +92,9 @@ in
         (defconst twist-running-emacs "${emacs.outPath}")
         (defconst twist-current-digest-file "${elispEnvDigest}")
       ''}
+        ${lib.optionalString (configurationRevision != null) ''
+          (defvar twist-configuration-revision "${configurationRevision}")
+        ''}
         ${
         lib.concatMapStrings (pkg: ''
           (load "${pkg}/share/emacs/site-lisp/${pkg.ename}-autoloads.el" t t)

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -11,7 +11,7 @@
   elispPackages,
   executablePackages,
   extraOutputsToInstall,
-  exportState,
+  exportManifest,
   configurationRevision,
 }: let
   inherit (builtins) length listToAttrs;
@@ -59,7 +59,7 @@
 
   infoPath = "${packageEnv}/share/info";
 
-  elispEnvState = writeText "elisp-digest.json" (builtins.toJSON {
+  elispManifest = writeText "elisp-digest.json" (builtins.toJSON {
     inherit configurationRevision;
     emacsPath = emacs.outPath;
     inherit nativeLoadPath infoPath;
@@ -89,9 +89,9 @@ in
 
     siteStartExtra = ''
       (when init-file-user
-        ${lib.optionalString exportState ''
+        ${lib.optionalString exportManifest ''
         (defconst twist-running-emacs "${emacs.outPath}")
-        (defconst twist-current-state-file "${elispEnvState}")
+        (defconst twist-current-manifest-file "${elispManifest}")
       ''}
         ${lib.optionalString (configurationRevision != null) ''
           (defvar twist-configuration-revision "${configurationRevision}")
@@ -104,9 +104,9 @@ in
       })
     '';
 
-    elispEnvStatePath =
-      if exportState
-      then elispEnvState.outPath
+    elispManifestPath =
+      if exportManifest
+      then elispManifest.outPath
       else null;
   }
   ''

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -106,7 +106,7 @@ in
     elispEnvStatePath =
       if exportState
       then elispEnvState.outPath
-      else "";
+      else null;
   }
   ''
     mkdir -p $out/bin

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -90,7 +90,7 @@ in
       (when init-file-user
         ${lib.optionalString exportState ''
         (defconst twist-running-emacs "${emacs.outPath}")
-        (defconst twist-current-digest-file "${elispEnvState}")
+        (defconst twist-current-state-file "${elispEnvState}")
       ''}
         ${lib.optionalString (configurationRevision != null) ''
           (defvar twist-configuration-revision "${configurationRevision}")

--- a/test/home.nix
+++ b/test/home.nix
@@ -25,6 +25,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
         createInitFile = true;
         earlyInitFile = ./early-init.el;
         config = emacs;
+        createManifestFile = true;
       };
     }
   ];


### PR DESCRIPTION
This PR adds an initial support for hot reloading of Emacs Lisp packages with twist.

Every time the systemd service is reloaded, a new digest of the package environment is sent to the running instance of Emacs. `twist-update` command of [twist.el](https://github.com/emacs-twist/twist.el) compares diffs of the package sets and reloads updated libraries. There is a plan on improvements on the UX.

Configuration:

- Set `exportManifest` option of twist to true.
- Set `programs.emacs-twist.createManifestFile` option of the home-manager module to true.
- Install [twist.el](https://github.com/emacs-twist/twist.el). Turn on `twist-watch-mode` mode.