### PR TITLE
Add a minimal API for checking masked built-in libraries

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -90,6 +90,11 @@ jobs:
       working-directory: test
 
     - run: |
+        nix eval --json .#${{ steps.system.outputs.emacs }}.maskedBuiltins \
+        | jq
+      working-directory: test
+
+    - run: |
         nix eval --json .#${{ steps.system.outputs.emacs }}.elispPackages.magit \
         | jq
       working-directory: test

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -141,6 +141,9 @@ in
     inherit builtinLibraryList;
     inherit depsCheck revDeps;
 
+    maskedBuiltins =
+      lib.intersectLists builtinLibraries (attrNames packageInputs);
+
     # An actual derivation set of Emacs Lisp packages. You can override this
     # attribute set to change how they are built.
     elispPackages = lib.makeScope self.newScope (eself:


### PR DESCRIPTION
Regarding #113, this is a minimal API for finding packages that are available as built-in libraries.

Usage:

```sh
nix eval .#emacs.maskedBuiltins [--raw|--json]
```

It prints a list of package names. Unless you have a specific reason to explicitly install them, you can remove `:ensure t` from `use-package` declarations (if you are using `use-package`) for those packages to prefer the built-in versions of the libraries.

@terlar You can use this to solve the problem you mentioned in https://github.com/emacs-twist/twist.nix/issues/112#issuecomment-1516040004:

>  I should probably go through my list of packages to exclude any other packages that might be bundled with Emacs nowadays.