### PR TITLE
Expose pkgs attribute from the scope for use in emacs-twist/overrides

### DIFF
--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -168,6 +168,10 @@ in
           // attrs))
       packageInputs);
 
+    # nixpkgs used in elisp build overrides. It is not meant to be overridden by
+    # the user.
+    pkgs = final;
+
     executablePackages =
       if addSystemPackages
       then


### PR DESCRIPTION
This enables [overrides](https://github.com/emacs-twist/overrides) to access the global nixpkgs scope of the user without complicating its API. 