### PR TITLE
Allow empty package versions when printing reverse dependencies

### DIFF
--- a/pkgs/emacs/tools/reverse.nix
+++ b/pkgs/emacs/tools/reverse.nix
@@ -14,7 +14,7 @@
     packageInputs;
 in
   mapAttrs (name: {
-    version,
+    version ? null,
     src,
     ...
   }: (


### PR DESCRIPTION
Fix the error in https://github.com/emacs-twist/twist.nix/actions/runs/6371070828/job/17292705607?pr=127#step:5:2692