### PR TITLE
Pass outPath explicitly to prevent use of builtins.storePath

### DIFF
--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -67,7 +67,7 @@ in
 
     builtinLibraryList = self.callPackage ./builtins.nix {};
 
-    builtinLibraries = lib.pipe (readFile builtinLibraryList) [
+    builtinLibraries = lib.pipe (readFile builtinLibraryList.outPath) [
       (split "\n")
       (filter (s: isString s && s != ""))
     ];


### PR DESCRIPTION
This should fix the following error as in https://github.com/akirak/flake-pins/actions/runs/6552791443/job/17825889253?pr=57

> error: 'builtins.storePath' is not allowed in pure evaluation mode