### PR TITLE
fix(test): Remove bbdb-notmuch.el from the bbdb source files

### DIFF
--- a/test/twist.nix
+++ b/test/twist.nix
@@ -44,6 +44,7 @@ emacsTwist {
   inputOverrides = {
     bbdb = _: super: {
       files = builtins.removeAttrs super.files [
+        "bbdb-notmuch.el"
         "bbdb-vm.el"
         "bbdb-vm-aux.el"
       ];


### PR DESCRIPTION
Closes #135.

bbdb package fails to compile because it doesn't have notmuch as a dependency. bbdb itself isn't specific to notmuch and shouldn't depend on the library, so I will exclude bbdb-notmuch.el from bbdb.