### PR TITLE
fix: Load Emacs libraries needed for native compilation

### DIFF
--- a/pkgs/emacs/build/comp-native.el
+++ b/pkgs/emacs/build/comp-native.el
@@ -5,6 +5,8 @@
 ;; Based on code from https://www.emacswiki.org/emacs/GccEmacs#h5o-14
 
 (defun run-native-compile-sync ()
+  (require 'bytecomp)
+  (require 'comp)
   (native-compile-async (or (pop command-line-args-left)
                             (error "Specify a source directory as the argument"))
                         nil nil


### PR DESCRIPTION
This fixes the following error which now appears in the latest Git version of Emacs:

> Symbol's function definition is void: emacs-lisp-compilation-mode