### PR TITLE
Add a new API for generating a fresh lock directory without configuration

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,6 +35,8 @@ jobs:
 
     - name: Test
       working-directory: test
-      run: nix develop -c just test
+      run: |
+        nix develop -c just test
+        nix develop -c just local-lock-2
 
     - run: nix flake show

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -206,13 +206,14 @@ in
       # have to run `nix flake lock`` in the target directory to update
       # flake.lock.
       lock =
-        generateLockFiles
-        {
-          packageInputs = enumerateConcretePackageSet "lock" explicitPackages;
-          flakeNix = true;
-          archiveLock = true;
-          postCommand = "nix flake lock";
-        }
+        (generateLockFiles
+          {
+            packageInputs = enumerateConcretePackageSet "lock" explicitPackages;
+            flakeNix = true;
+            archiveLock = true;
+            postCommand = "nix flake lock";
+          })
+        .asAppWritingToRelativeDir
         lockDirName;
 
       # Generate flake.lock with the current revisions
@@ -224,11 +225,12 @@ in
 
       # Generate archive.lock with latest packages from ELPA package archives
       update =
-        generateLockFiles
-        {
-          packageInputs = enumerateConcretePackageSet "update" explicitPackages;
-          archiveLock = true;
-        }
+        (generateLockFiles
+          {
+            packageInputs = enumerateConcretePackageSet "update" explicitPackages;
+            archiveLock = true;
+          })
+        .asAppWritingToRelativeDir
         lockDirName;
     };
   })

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -217,13 +217,6 @@ in
         .asAppWritingToRelativeDir
         lockDirName;
 
-      # Generate flake.lock with the current revisions
-      #
-      # sync = generateLockFiles {
-      #   inherit packageInputs;
-      #   flakeLock = true;
-      # };
-
       # Generate archive.lock with latest packages from ELPA package archives
       update =
         (generateLockFiles

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -17,6 +17,11 @@
   # These packages won't be declared in the generated flake.nix to not produce
   # meaningless diffs in flake.lock.
   localPackages ? [],
+  # Commands to run after running generateLockDir. The command is run at the
+  # root of the Git repository containing the lock directory. For example, if
+  # you have added the lock directory as a subflake, you can run `nix flake lock
+  # --update-input <input name>` to update the flake input.
+  postCommandOnGeneratingLockDir ? null,
   # User-provided list of Emacs built-in libraries as a string list
   initialLibraries ? null,
   addSystemPackages ? true,
@@ -218,7 +223,7 @@ in
         flakeNix = true;
         archiveLock = true;
       })
-      .writerScript;
+      .writerScript {inherit postCommandOnGeneratingLockDir;};
 
     makeApps = {lockDirName}: {
       # Generate flake.nix and archive.lock with a complete package set. You

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -202,6 +202,16 @@ in
     # This makes the attrset a derivation for a shorthand.
     inherit (self.emacsWrapper) name type outputName outPath drvPath;
 
+    # A package/derivation for a command that accepts a directory as an argument
+    # and write lock files to it
+    generateLockDir =
+      (generateLockFiles {
+        packageInputs = enumerateConcretePackageSet "update" explicitPackages;
+        flakeNix = true;
+        archiveLock = true;
+      })
+      .writerScript;
+
     makeApps = {lockDirName}: {
       # Generate flake.nix and archive.lock with a complete package set. You
       # have to run `nix flake lock`` in the target directory to update

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -142,14 +142,15 @@ in
             // lib.optionalAttrs (isAttrs attrs.src && attrs.src ? rev) {
               sourceInfo =
                 lib.filterAttrs
-                  (name: _: elem name [
+                (name: _:
+                  elem name [
                     "lastModified"
                     "lastModifiedDate"
                     "narHash"
                     "rev"
                     "shortRev"
                   ])
-                  attrs.src;
+                attrs.src;
             })
       ))
     ];

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -13,8 +13,9 @@
   flakeNix ? false,
   flakeLock ? false,
   archiveLock ? false,
+  # Command run after writing the directory in asAppWritingToRelativeDir
   postCommand ? null,
-}: outDir:
+}:
 assert (flakeNix || flakeLock || archiveLock); let
   inherit (builtins) toJSON attrNames mapAttrs;
 
@@ -79,39 +80,15 @@ assert (flakeNix || flakeLock || archiveLock); let
       ${lib.optionalString flakeLock generateFlakeLock}
       ${lib.optionalString archiveLock generateArchiveLock}
     '';
-
-  writeToDir = writeShellScript "lock" ''
-    outDir="${outDir}"
-
-    if [[ ! -d "$outDir" ]]
-    then
-      echo >&2 "Error: Directory $outDir does not exist"
-      echo >&2 "Did you run the script from outside the source repository?"
-      echo >&2 "If this is what you intended, you should create the directory in advance."
-      echo >&2 "Aborting"
-      exit 1
-    fi
-
-    for file in "$outDir/flake.nix" "$outDir/archive.lock"
-    do
-      if [[ ! -f "$file" ]]
-      then
-        touch "$file"
-        git add "$file"
-      fi
-    done
-
-    install -m 644 -t "$outDir" ${src}/*.*
-
-    ${lib.optionalString (postCommand != null) ''
-      cd "$outDir"
-      ${postCommand}
-    ''}
-  '';
-in
-  # This is an app, and not a derivation. See
-  # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps
-  {
+in {
+  asAppWritingToRelativeDir = outDir: {
+    # This is an app, and not a derivation. See
+    # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps
     type = "app";
-    program = writeToDir.outPath;
-  }
+    program =
+      (import ./write-lock-1.nix {inherit lib writeShellScript;} {
+        inherit outDir src postCommand;
+      })
+      .outPath;
+  };
+}

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -6,6 +6,7 @@
   runCommandLocal,
   writeTextFile,
   writeShellScript,
+  writeShellApplication,
   # Current version
   flakeLockFile ? null,
 }: {
@@ -80,5 +81,12 @@ in {
         inherit outDir src postCommand;
       })
       .outPath;
+  };
+
+  writerScript = writeShellApplication {
+    name = "emacs-twist-write-lock";
+    text =
+      builtins.replaceStrings ["@lockSrcDir@"] [src.outPath]
+      (builtins.readFile ./write-lock-2.bash);
   };
 }

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -83,10 +83,21 @@ in {
       .outPath;
   };
 
-  writerScript = writeShellApplication {
-    name = "emacs-twist-write-lock";
-    text =
-      builtins.replaceStrings ["@lockSrcDir@"] [src.outPath]
-      (builtins.readFile ./write-lock-2.bash);
-  };
+  writerScript = {postCommandOnGeneratingLockDir}:
+    writeShellApplication {
+      name = "emacs-twist-write-lock";
+      text =
+        builtins.replaceStrings [
+          "@lockSrcDir@"
+          "@postCommand@"
+        ] [
+          src.outPath
+          (lib.optionalString (builtins.isString postCommandOnGeneratingLockDir) ''
+            ( cd "$outDir" && cd "$(git rev-parse --show-toplevel)" &&
+              ( ${postCommandOnGeneratingLockDir} )
+            )
+          '')
+        ]
+        (builtins.readFile ./write-lock-2.bash);
+    };
 }

--- a/pkgs/emacs/lock/write-lock-1.nix
+++ b/pkgs/emacs/lock/write-lock-1.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  writeShellScript,
+}: {
+  outDir,
+  src,
+  postCommand,
+}:
+writeShellScript "lock" ''
+  outDir="${outDir}"
+
+  if [[ ! -d "$outDir" ]]
+  then
+    echo >&2 "Error: Directory $outDir does not exist"
+    echo >&2 "Did you run the script from outside the source repository?"
+    echo >&2 "If this is what you intended, you should create the directory in advance."
+    echo >&2 "Aborting"
+    exit 1
+  fi
+
+  for file in "$outDir/flake.nix" "$outDir/archive.lock"
+  do
+    if [[ ! -f "$file" ]]
+    then
+      touch "$file"
+      git add "$file"
+    fi
+  done
+
+  install -m 644 -t "$outDir" ${src}/*.*
+
+  ${lib.optionalString (postCommand != null) ''
+    cd "$outDir"
+    ${postCommand}
+  ''}
+''

--- a/pkgs/emacs/lock/write-lock-2.bash
+++ b/pkgs/emacs/lock/write-lock-2.bash
@@ -1,0 +1,105 @@
+updateFlakeLock=1
+force=0
+src='@lockSrcDir@'
+
+function usage() {
+  name=$(basename "$0")
+  echo "Usage: $name [--no-update-flake-lock] [-f|--force] DIR"
+  # TODO: Add descriptions of the options
+}
+
+function err() {
+  echo >&2 "$*"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit
+      ;;
+    --no-update-flake-lock)
+      updateFlakeLock=0
+      shift
+      ;;
+    -f | --force)
+      force=1
+      shift
+      ;;
+    -*)
+      echo >&2 "Unsupported option $1"
+      exit 1
+      ;;
+    *)
+      if [[ -v outDir ]] && [[ -n "$outDir" ]]; then
+        err "Only one output directory is supported"
+        exit 1
+      fi
+      outDir=$(realpath "$1")
+      shift
+      ;;
+  esac
+done
+
+function checkSettings() {
+  if ! [[ -v outDir ]] || [[ -z "$outDir" ]]; then
+    err "You need to specify an output directory as an argument"
+    usage
+    exit 1
+  fi
+
+  if [[ -d "$outDir" ]] && [[ "$force" -ne 1 ]]; then
+    err "Directory $outDir already exists."
+    err "Set --force as an argument to run anyway"
+    exit 1
+  fi
+
+  local parent
+  parent=$(dirname "$outDir")
+  if [[ $( cd "$parent" && git-rev-parse --is-inside-work-tree 2>/dev/null ) = true ]]; then
+    err "Directory $outDir is not inside a Git working tree"
+  fi
+}
+
+function copyFiles() {
+  mkdir -p "$outDir"
+  cd "$src"
+  for f in *.*; do
+    # The nix3 commands don't work locally if flake.nix isn't added to the Git
+    # repository. Here, an empty file will be added if the file doesn't exist in
+    # the Git index. The user can confirm the actual content of generated lock
+    # files before committing to the repository.
+    ( set -euo pipefail;
+      cd "$outDir";
+      if [[ -z $(git ls-files --cached "$f") ]]; then
+        if [[ -e "$f" ]]; then
+          err "File $f exists locally but not in the Git index."
+          err "Aborting due to an unexpected state"
+          exit 1
+        else
+          touch "$f"
+          git add "$f"
+        fi
+      fi
+    )
+
+    if [[ -f "$outDir/$f" ]] && diff -q "$outDir/$f" "$f" >/dev/null; then
+      echo >&2 "'$f': not changed"
+      continue
+    fi
+
+    install -v -m 644 -t "$outDir" "$f"
+  done
+}
+
+function runNix() {
+  if [[ "$updateFlakeLock" = 1 ]]; then
+    ( set -x; cd "$outDir" && nix flake update )
+  else
+    ( set -x; cd "$outDir" && nix flake lock )
+  fi
+}
+
+checkSettings
+copyFiles
+runNix

--- a/pkgs/emacs/lock/write-lock-2.bash
+++ b/pkgs/emacs/lock/write-lock-2.bash
@@ -103,3 +103,4 @@ function runNix() {
 checkSettings
 copyFiles
 runNix
+@postCommand@

--- a/test/justfile
+++ b/test/justfile
@@ -9,6 +9,21 @@ local-lock:
 local-update:
     nix run .\#update --impure --override-input twist "path:$(readlink -f ..)"
 
+local-lock-2:
+    nix run .\#emacs.generateLockDir --impure \
+      --override-input twist "path:$(readlink -f ..)" \
+      -- ./lock2
+    [[ -d lock2 ]]
+    [[ -f lock2/flake.lock ]]
+    nix run .\#emacs.generateLockDir --impure \
+      --override-input twist "path:$(readlink -f ..)" \
+      -- --force ./lock2
+    nix run .\#emacs.generateLockDir --impure \
+      --override-input twist "path:$(readlink -f ..)" \
+      -- --force --no-update-flake-lock ./lock2
+    rm -r ./lock2
+    git rm -r --cached ./lock2
+
 # Used for CI.
 local-update-flake:
     nix flake update --override-input twist "path:$(readlink -f ..)"

--- a/test/justfile
+++ b/test/justfile
@@ -15,6 +15,7 @@ local-lock-2:
       -- ./lock2
     [[ -d lock2 ]]
     [[ -f lock2/flake.lock ]]
+    [[ -f lock-success ]]
     nix run .\#emacs.generateLockDir --impure \
       --override-input twist "path:$(readlink -f ..)" \
       -- --force ./lock2
@@ -23,6 +24,7 @@ local-lock-2:
       -- --force --no-update-flake-lock ./lock2
     rm -r ./lock2
     git rm -r --cached ./lock2
+    rm lock-success
 
 # Used for CI.
 local-update-flake:

--- a/test/twist.nix
+++ b/test/twist.nix
@@ -50,4 +50,7 @@ emacsTwist {
       ];
     };
   };
+  postCommandOnGeneratingLockDir = ''
+    touch test/lock-success
+  '';
 }


### PR DESCRIPTION
This will add a new API for generating a lock directory without pre-configuring the location of the directory.

a. This feature is especially important for managing multiple lock directories within a single project. The user can specify the lock directory to be created at runtime, so the configuration won't be complicated. Also, the output directory must be explicitly specified, so there is a much less likelihood of accidentally destroying files by running the command outside a designated project.

The command lines look tedious, but your shell (e.g. zsh) may have good Nix completions that save an effort of typing.

Example usages are shown below:

Create a new lock directory. The directory must not exist:

```sh
nix run .\#emacs-config.generateLockDir -L --impure -- ./lock
```

Create a lock directory. With `--force/-f` option, it is allowed to override an existing lock directory. If there are existing lock files, all lock entries will be updated (for `flake.lock`, `nix flake update` will be run in the lock directory to update it):

```sh
nix run .\#emacs-config.generateLockDir -L --impure -- --force ./lock
```

Create a lock directory. If `--no-update-flake-lock` flag is given, `nix flake lock` is used to add missing lock entries instead of `nix flake update`, so existing lock entries won't be updated. `archive.lock` is recreated, so all archive packages will become the latest:

```sh
nix run .\#emacs-config.generateLockDir -L --impure -- --no-update-flake-lock --force ./lock
```

This API is heavier than the previous one, so the older API will remain for the time being.

b. Another feature is `localPackages` option, which lets the user specify a list of packages to be not included in the generated `flake.nix`.