### PR TITLE
fix: invalid regex on darwin

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,7 +19,12 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,12 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26

--- a/pkgs/build-support/elisp/parseElispHeaders.nix
+++ b/pkgs/build-support/elisp/parseElispHeaders.nix
@@ -10,7 +10,7 @@ with builtins; let
   dropWhile = import ../utils/dropWhile.nix;
 
   # Regular expression patterns
-  descriptionRegex = ";;;.+ --- (.+?)";
+  descriptionRegex = ";;;.+ --- (.+)";
   magicHeaderRegex = "(.+)-\\*-.+-\\*-[[:space:]]*";
   headerRegex = ";;[[:space:]]*(.*[^[:space:]]):([[:space:]]*.*)?";
 

--- a/pkgs/build-support/gitUrlToAttrs.nix
+++ b/pkgs/build-support/gitUrlToAttrs.nix
@@ -1,6 +1,6 @@
 s:
 with builtins; let
-  githubMatch = match "https://github.com/(.+)/(.+?)" s;
+  githubMatch = match "https://github.com/(.+)/(.+)" s;
 in
   if githubMatch != null
   then {


### PR DESCRIPTION
Japanese follows English.

When I try to use twist with darwin, I get an INVALID REGULAR EXPRESSION error.
This PR will fix that.

The behavior of buitlins.match seemed to be different between linux and darwin.
ref; https://github.com/NixOS/nix/issues/1537

--

twistをdarwinで使おうとするとinvalid regular expressionのエラーが発生します。
このPRではそれを修正します。

buitlins.match の挙動は linux と darwin で異なるようでした。
ref; https://github.com/NixOS/nix/issues/1537
