### PR TITLE
fix: Update on renaming functions in upstream comp-run.el

### DIFF
--- a/pkgs/emacs/build/comp-native.el
+++ b/pkgs/emacs/build/comp-native.el
@@ -4,9 +4,13 @@
 ;;
 ;; Based on code from https://www.emacswiki.org/emacs/GccEmacs#h5o-14
 
+(require 'comp-run)
+
+(if (fboundp 'comp--async-runnings)
+    (defalias 'twist--comp-async-runnings #'comp--async-runnings)
+  (defalias 'twist--comp-async-runnings #'comp-async-runnings))
+
 (defun run-native-compile-sync ()
-  (require 'bytecomp)
-  (require 'comp)
   (native-compile-async (or (pop command-line-args-left)
                             (error "Specify a source directory as the argument"))
                         nil nil
@@ -14,6 +18,6 @@
                           (and (string-match-p "^[^.]" (file-name-nondirectory name))
                                (not (string-suffix-p "-pkg.el" name)))))
   (while (or comp-files-queue
-             (> (comp-async-runnings) 0))
+             (> (twist--comp-async-runnings) 0))
     ;; Calibration may be needed
     (sleep-for 0.3)))


### PR DESCRIPTION
Fixes #161. Now twist depends on a private function from GNU Emacs. I will consider other options once we encounter a further breakage in this function.