### PR TITLE
feat(build): allow extra site-start elisp

### DIFF
--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -40,6 +40,7 @@
   # (experimental). Needed if you use the hot-reloading feature of twist.el.
   exportManifest ? false,
   configurationRevision ? null,
+  extraSiteStartElisp ? "",
 }: let
   inherit
     (builtins)
@@ -213,7 +214,7 @@ in
       self.callPackage ./wrapper.nix
       {
         packageNames = attrNames packageInputs;
-        inherit extraOutputsToInstall exportManifest configurationRevision;
+        inherit extraOutputsToInstall exportManifest configurationRevision extraSiteStartElisp;
       };
 
     # This makes the attrset a derivation for a shorthand.

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -13,6 +13,7 @@
   extraOutputsToInstall,
   exportManifest,
   configurationRevision,
+  extraSiteStartElisp,
 }: let
   inherit (builtins) length listToAttrs;
 
@@ -101,7 +102,8 @@ in
           (load "${pkg}/share/emacs/site-lisp/${pkg.ename}-autoloads.el" t t)
         '')
         elispInputs
-      })
+        })
+      ${extraSiteStartElisp}
     '';
 
     elispManifestPath =


### PR DESCRIPTION
Bring your own extra site-start elisp. Used it to do treesitter: https://github.com/jordanisaacs/emacs-config/commit/b3311f31150e7bf015563f35b25cf769d847bfa1