### PR TITLE
Add an option to parse all main files directly

### DIFF
--- a/pkgs/emacs/data/default.nix
+++ b/pkgs/emacs/data/default.nix
@@ -27,6 +27,7 @@ in
     archiveLockFile,
     inputOverrides,
     elispPackagePins,
+    defaultMainIsAscii,
   }: mode: let
     toLockData = {
       nodes,
@@ -92,7 +93,7 @@ in
         );
 
     getPackageData = revDep: ename:
-      lib.makeExtensible (import ./package.nix {inherit lib linkFarm;}
+      lib.makeExtensible (import ./package.nix {inherit lib linkFarm defaultMainIsAscii;}
         ename
         # It would be nice if it were possible to set the pin from inside
         # overrideInputs, but it causes infinite recursion unfortunately :(

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -22,7 +22,11 @@ let
     isFunction
     ;
 in
-  {lib, linkFarm}: ename: mkAttrs: self: let
+  {
+    lib,
+    linkFarm,
+    defaultMainIsAscii,
+  }: ename: mkAttrs: self: let
     attrs =
       if isAttrs mkAttrs
       then mkAttrs
@@ -63,7 +67,7 @@ in
       lib.parseElispHeaders
       (
         # Add support for an option to remove IFD.
-        if self.mainIsAscii or false
+        if self.mainIsAscii or defaultMainIsAscii
         then builtins.readFile (self.src + "/${self.mainFile}")
         else
           (lib.readFirstBytes
@@ -88,12 +92,13 @@ in
         # If the source if a single-file archive from ELPA or MELPA, src will be
         # a file, and not a directory, so the file should be put in a directory.
         if attrs.inventory.type == "archive" && attrs.archive.type == "file"
-        then linkFarm (ename + ".el") [
-          {
-            name = ename + ".el";
-            path = attrs.src;
-          }
-        ]
+        then
+          linkFarm (ename + ".el") [
+            {
+              name = ename + ".el";
+              path = attrs.src;
+            }
+          ]
         else attrs.src;
 
       files = attrs.files or (lib.expandMelpaRecipeFiles self.src null);

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -36,6 +36,11 @@
     if wantExtraOutputs
     then ["info"]
     else [],
+  # Assume the main files of all packages contain only ASCII characters. This is
+  # a requirement for avoiding IFD, but some libraries actually contain
+  # non-ASCII characters, which cannot be parsed with `builtins.readFile`
+  # function of Nix.
+  defaultMainIsAscii ? false,
   # Export a manifest file of of the package set from the wrapper
   # (experimental). Needed if you use the hot-reloading feature of twist.el.
   exportManifest ? false,
@@ -101,6 +106,7 @@ in
         archiveLockFile
         builtinLibraries
         inputOverrides
+        defaultMainIsAscii
         ;
       # Just remap the name
       inventories = registries;


### PR DESCRIPTION
This new `defaultMainIsAscii` option assumes that all main files contain only ASCII characters and parses them directly using `builtins.readFile`. By setting option, you can add individual Emacs Lisp packages to the flake outputs and show them in `nix flake show` without IFD. 

This feature is a requirement in [rice](https://github.com/emacs-twist/rice-config), the new project for Emacs Lisp package development.