### PR TITLE
Add a function for building ELPA-compatible package archives

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -41,4 +41,21 @@ in
       (split "\n")
       (filter (s: isString s && s != ""))
     ];
+
+  buildElpaArchive =
+    pkgs: attrs:
+    let
+      lib = import ../pkgs/build-support {
+        inherit inputs pkgs;
+      };
+      attrs' = {
+        elispInputs = [ ];
+        dontByteCompile = true;
+        wantExtraOutputs = true;
+        nativeCompileAhead = false;
+      } // attrs;
+
+      convertToElpaArchive = pkgs.callPackage ../pkgs/build-support/elisp/convertToElpaArchive.nix { };
+    in
+    convertToElpaArchive attrs (pkgs.callPackage ../pkgs/emacs/build { inherit lib; } attrs');
 }

--- a/pkgs/build-support/elisp/convertToElpaArchive.nix
+++ b/pkgs/build-support/elisp/convertToElpaArchive.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  runCommand,
+  texinfo,
+}:
+{
+  ename,
+  version ? null,
+  meta,
+  sourceInfo ? null,
+  packageRequires,
+  # There are some missing attributes desired for the package description, but
+  # omit them for now.
+  ...
+}:
+drv:
+let
+  attrsToLispAlist =
+    attrs:
+    "("
+    + lib.pipe attrs [
+      (lib.mapAttrsToList (name: value: "(${name} \"${value}\")"))
+      (builtins.concatStringsSep " ")
+    ]
+    + ")";
+
+  hasInfo = builtins.elem "info" drv.outputs;
+
+  commitInfo = lib.optionalString (sourceInfo != null && sourceInfo ? rev) ''
+    :commit "${sourceInfo.rev}"
+  '';
+
+  versionString = if version != null then version else "0";
+in
+runCommand "${ename}-${versionString}"
+  {
+    buildInputs = lib.optional hasInfo texinfo;
+
+    pkgDescription = ''
+      (define-package "${ename}" "${versionString}" "${meta.description}"
+        '${attrsToLispAlist (builtins.mapAttrs (_: v: if v != null then v else "0") packageRequires)}
+        ${commitInfo})
+      ;; Local Variables:
+      ;; no-byte-compile: t
+      ;; End:
+    '';
+
+    passAsFile = [ "pkgDescription" ];
+  }
+  ''
+    mkdir $out
+    cd $out
+    install -m 644 $pkgDescriptionPath ${ename}-pkg.el
+    ${lib.optionalString hasInfo ''
+      if [[ -d ${drv.info}/share/info ]]
+      then
+        shopt -s nullglob
+        for i in ${drv.info}/share/info/*.info ${drv.info}/share/info/*.info.gz
+        do
+          install -m 644 -t . $i
+          install-info $(basename $i) $out/dir
+        done
+      fi
+    ''}
+    (cd ${drv.outPath}/share/emacs/site-lisp \
+     && tar cf - \
+        --exclude='*-autoloads.el' \
+        .) | tar xf -
+  ''

--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -14,6 +14,7 @@
   nativeCompileAhead,
   wantExtraOutputs,
   elispInputs,
+  dontByteCompile ? false,
   ...
 } @ attrs:
 with builtins; let
@@ -132,8 +133,8 @@ in
       lib.makeSearchPath "share/emacs/native-lisp/" elispInputs
     }:";
 
-    dontByteCompile = false;
     errorOnWarn = false;
+  inherit dontByteCompile;
 
     buildCmd = ''
       # Don't make the package description of package.el available

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -3,11 +3,11 @@
     "elisp-helpers": {
       "flake": false,
       "locked": {
-        "lastModified": 1693912311,
-        "narHash": "sha256-UqBnIr3Zx4kWNutcuM3YiH6BvJiSCU1eQX53+1whCkQ=",
+        "lastModified": 1726250243,
+        "narHash": "sha256-WVOB3hOsm8Zgfmrmrr0zEAjnduQ5l2CaHIFer5Xy6F8=",
         "owner": "emacs-twist",
         "repo": "elisp-helpers",
-        "rev": "cd21b8951701b048a794ea67c482c53e834440b5",
+        "rev": "e737e494c3e7c51e3033b35ab5df009209b36bcc",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "elisp-helpers_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1693912311,
-        "narHash": "sha256-UqBnIr3Zx4kWNutcuM3YiH6BvJiSCU1eQX53+1whCkQ=",
+        "lastModified": 1726250243,
+        "narHash": "sha256-WVOB3hOsm8Zgfmrmrr0zEAjnduQ5l2CaHIFer5Xy6F8=",
         "owner": "emacs-twist",
         "repo": "elisp-helpers",
-        "rev": "cd21b8951701b048a794ea67c482c53e834440b5",
+        "rev": "e737e494c3e7c51e3033b35ab5df009209b36bcc",
         "type": "github"
       },
       "original": {
@@ -440,6 +440,84 @@
         "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.1.tar.xz"
       }
     },
+    "emacs-29-2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705573161,
+        "narHash": "sha256-P589A1XNkmj4ODOXosk1sNkUGJsHSgQtIfWsNjCd+eI=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.2.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.2.tar.xz"
+      }
+    },
+    "emacs-29-2_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705573161,
+        "narHash": "sha256-P589A1XNkmj4ODOXosk1sNkUGJsHSgQtIfWsNjCd+eI=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.2.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.2.tar.xz"
+      }
+    },
+    "emacs-29-3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1711287509,
+        "narHash": "sha256-F/EO5gasb0bW0TIyudp1HAeZfwYjjE7a3ptK2oQbp7Q=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
+      }
+    },
+    "emacs-29-3_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1711287509,
+        "narHash": "sha256-F/EO5gasb0bW0TIyudp1HAeZfwYjjE7a3ptK2oQbp7Q=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.3.tar.xz"
+      }
+    },
+    "emacs-29-4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719016405,
+        "narHash": "sha256-p4jFYnpWdq7op8VqMpvEgdXNkqpyxznli5q6K1TEohk=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
+      }
+    },
+    "emacs-29-4_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719016405,
+        "narHash": "sha256-p4jFYnpWdq7op8VqMpvEgdXNkqpyxznli5q6K1TEohk=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
+      }
+    },
     "emacs-builtins": {
       "inputs": {
         "emacs-ci": "emacs-ci",
@@ -448,11 +526,11 @@
         "twist": "twist"
       },
       "locked": {
-        "lastModified": 1697891853,
-        "narHash": "sha256-MBkPbDzX0clZ+7w6c7+Uh0Np8ybfQtYG/0VBR2TMRgo=",
+        "lastModified": 1726500114,
+        "narHash": "sha256-8Z9VCGH7zIBwcvjR8EAsQCFOnsAiWYQbHm50UqEAFyk=",
         "owner": "emacs-twist",
         "repo": "emacs-builtins",
-        "rev": "c2e59cbb6a6b96856e5712eabadba434d0eac6ee",
+        "rev": "74eafd753ffcdac54839fe81d73c251a622e6913",
         "type": "github"
       },
       "original": {
@@ -480,6 +558,9 @@
         "emacs-28-1": "emacs-28-1",
         "emacs-28-2": "emacs-28-2",
         "emacs-29-1": "emacs-29-1",
+        "emacs-29-2": "emacs-29-2",
+        "emacs-29-3": "emacs-29-3",
+        "emacs-29-4": "emacs-29-4",
         "emacs-release-snapshot": "emacs-release-snapshot",
         "emacs-snapshot": "emacs-snapshot",
         "flake-compat": "flake-compat",
@@ -487,11 +568,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1697451707,
-        "narHash": "sha256-NJ678bUxp+h/tI1UtL3he83eEHNUgqKNEHwzxXF+SZw=",
+        "lastModified": 1726488176,
+        "narHash": "sha256-oKaA6ZMcPqAICkPKDFCpxEdpAG46ypJk/AUROeBb2Hw=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "bab13351da16d41966f2767822cd0ddeeb74dce1",
+        "rev": "d38634ec66579f89f42baccb198323a26330fd60",
         "type": "github"
       },
       "original": {
@@ -519,6 +600,9 @@
         "emacs-28-1": "emacs-28-1_2",
         "emacs-28-2": "emacs-28-2_2",
         "emacs-29-1": "emacs-29-1_2",
+        "emacs-29-2": "emacs-29-2_2",
+        "emacs-29-3": "emacs-29-3_2",
+        "emacs-29-4": "emacs-29-4_2",
         "emacs-release-snapshot": "emacs-release-snapshot_2",
         "emacs-snapshot": "emacs-snapshot_2",
         "flake-compat": "flake-compat_2",
@@ -526,11 +610,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1695636769,
-        "narHash": "sha256-GGIV1Hz6Sv4+g0dMW5+R8tPnhZOTGgOu0kLZoSH1z2M=",
+        "lastModified": 1726488176,
+        "narHash": "sha256-oKaA6ZMcPqAICkPKDFCpxEdpAG46ypJk/AUROeBb2Hw=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "2f5140545a3d0e73eb11ec76ba7f7b3c3f4d4f96",
+        "rev": "d38634ec66579f89f42baccb198323a26330fd60",
         "type": "github"
       },
       "original": {
@@ -542,16 +626,16 @@
     "emacs-release-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1697365603,
-        "narHash": "sha256-HKF49u9eVHRbr9nemtzqNj2ph1FbyRXnAyPqOgQZ0Jc=",
+        "lastModified": 1726388934,
+        "narHash": "sha256-YDXnekibbsFn7xtWIWWM0UQaOzWZPo9/I7nLxcTFS9Q=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "07c45f20fd3828548d5f0c110034e9857a94ccaf",
+        "rev": "c6077015894dd89c5aa3811bf55d3124394874d0",
         "type": "github"
       },
       "original": {
         "owner": "emacs-mirror",
-        "ref": "emacs-29",
+        "ref": "emacs-30",
         "repo": "emacs",
         "type": "github"
       }
@@ -559,16 +643,16 @@
     "emacs-release-snapshot_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1695627156,
-        "narHash": "sha256-dGWmAhfFwQkwZXXDkm1fPVvpKDse3Z/47bL37RrGeSI=",
+        "lastModified": 1726388934,
+        "narHash": "sha256-YDXnekibbsFn7xtWIWWM0UQaOzWZPo9/I7nLxcTFS9Q=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "ca5b48fd76db2ab7c154c2db6a7d4a9fb7857f6c",
+        "rev": "c6077015894dd89c5aa3811bf55d3124394874d0",
         "type": "github"
       },
       "original": {
         "owner": "emacs-mirror",
-        "ref": "emacs-29",
+        "ref": "emacs-30",
         "repo": "emacs",
         "type": "github"
       }
@@ -576,11 +660,11 @@
     "emacs-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1697444059,
-        "narHash": "sha256-JiKHKGoqAeH1cKzk4r7spNBb2nN2T5Sq5agqQN8juGY=",
+        "lastModified": 1726401756,
+        "narHash": "sha256-THCUPJnGyBlbJEyd/jbE8MIovCt2AymgZOTS8a+BNWk=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "c3038bf5e1d79c3dfa83717a5a61ecc86116f04a",
+        "rev": "f27553c30a772a0103d2e6762e4d7f588f302e4b",
         "type": "github"
       },
       "original": {
@@ -592,11 +676,11 @@
     "emacs-snapshot_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1695618104,
-        "narHash": "sha256-ccM18Y4hngG/HlCuP9T9+jonmRk9ONtYBne1u2+/ylc=",
+        "lastModified": 1726401756,
+        "narHash": "sha256-THCUPJnGyBlbJEyd/jbE8MIovCt2AymgZOTS8a+BNWk=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "df5a9a78b51f2f42d2dbb010e811a239fc014732",
+        "rev": "f27553c30a772a0103d2e6762e4d7f588f302e4b",
         "type": "github"
       },
       "original": {
@@ -608,11 +692,11 @@
     "epkgs": {
       "flake": false,
       "locked": {
-        "lastModified": 1695592458,
-        "narHash": "sha256-CgkZ9kn/uduB852paOPR1+i2+GxL287GA8Ewk7FtHMg=",
+        "lastModified": 1726527772,
+        "narHash": "sha256-fRrTvn/P4jeKggzg03kuuqP5iusJvOXzJn0qHd+qMUw=",
         "owner": "emacsmirror",
         "repo": "epkgs",
-        "rev": "36a6dc6ff4fb1d2440ffa2dae5fdfb63cf0901d6",
+        "rev": "c6dcbb0e9fa5e4aabd2856a335f40d9115caf526",
         "type": "github"
       },
       "original": {
@@ -690,11 +774,11 @@
     "gnu-elpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1695587073,
-        "narHash": "sha256-KiQshz20IvyMpleHRdN0gpcOGENCO6yBJY0OtyIgq8o=",
+        "lastModified": 1726495031,
+        "narHash": "sha256-XHXE3FcoK2qpaYqzjRVGSt1BUOYRmGu5YnZydmMoGzE=",
         "ref": "main",
-        "rev": "70781350853e176a7015b1ede2a1908c1a264700",
-        "revCount": 540,
+        "rev": "28b18a087b5394d71f5014d3295fb312aa79de25",
+        "revCount": 634,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/elpa.git"
       },
@@ -709,11 +793,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1695738267,
-        "narHash": "sha256-LTNAbTQ96xSj17xBfsFrFS9i56U2BMLpD0BduhrsVkU=",
+        "lastModified": 1726611255,
+        "narHash": "sha256-/bxaYvIK6/d3zqpW26QFS0rqfd0cO4qreSNWvYLTl/w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f4e5b4999fd6a42ece5da8a3a2439a50e48e486",
+        "rev": "d2493de5cd1da06b6a4c3e97f4e7d5dd791df457",
         "type": "github"
       },
       "original": {
@@ -725,11 +809,11 @@
     "melpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1695591923,
-        "narHash": "sha256-bk7o3iPO3X5cvsVdoKijFDiQNvwTvkSEXzVhhJgFyfc=",
+        "lastModified": 1726515996,
+        "narHash": "sha256-QqbOC6i0XVl/KjGeS73oIv10upA8WHWjifwE4fB/PV0=",
         "owner": "melpa",
         "repo": "melpa",
-        "rev": "369b39722775636c528c8e1194df878f9e2cd03b",
+        "rev": "167e18767d96bdac08b5d10b1feb1c6fcaafd074",
         "type": "github"
       },
       "original": {
@@ -740,11 +824,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695978539,
-        "narHash": "sha256-lta5HToBZMWZ2hl5CautNSUgIZViR41QxN7JKbMAjgQ=",
+        "lastModified": 1725099143,
+        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd9b686c0168041aea600222be0805a0de6e6ab8",
+        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
         "type": "github"
       },
       "original": {
@@ -755,11 +839,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694937365,
-        "narHash": "sha256-iHZSGrb9gVpZRR4B2ishUN/1LRKWtSHZNO37C8z1SmA=",
+        "lastModified": 1725534445,
+        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d017a8822e0907fb96f7700a319f9fe2434de02",
+        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
         "type": "github"
       },
       "original": {
@@ -769,11 +853,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1693355128,
-        "narHash": "sha256-+ZoAny3ZxLcfMaUoLVgL9Ywb/57wP+EtsdNGuXUJrwg=",
+        "lastModified": 1725099143,
+        "narHash": "sha256-CHgumPZaC7z+WYx72WgaLt2XF0yUVzJS60rO4GZ7ytY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a63a64b593dcf2fe05f7c5d666eb395950f36bc9",
+        "rev": "5629520edecb69630a3f4d17d3d33fc96c13f6fe",
         "type": "github"
       },
       "original": {
@@ -784,11 +868,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1695360818,
-        "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e35dcc04a3853da485a396bdd332217d0ac9054f",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -800,11 +884,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1695644571,
-        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
         "type": "github"
       },
       "original": {
@@ -817,11 +901,11 @@
     "nongnu": {
       "flake": false,
       "locked": {
-        "lastModified": 1694131679,
-        "narHash": "sha256-e6itLlnjmGHdnQdiV47966+VDimfckIMGRLIfBNP9iQ=",
+        "lastModified": 1725430635,
+        "narHash": "sha256-X5C5Rpx3yfAWiFYbOdvle/xDcdCpeOOuy8K0mOBk2xA=",
         "ref": "main",
-        "rev": "7be7879e3ea01401ff51a515da882e79148392ea",
-        "revCount": 291,
+        "rev": "94966229ca17882de6cbc1b709120e19a030d35d",
+        "revCount": 329,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/nongnu.git"
       },
@@ -910,11 +994,11 @@
         "elisp-helpers": "elisp-helpers"
       },
       "locked": {
-        "lastModified": 1697717645,
-        "narHash": "sha256-Dsp18h1fUWcqkBEHrs4itmkBvP/IZlDcE88c7Ne10/g=",
+        "lastModified": 1726250271,
+        "narHash": "sha256-kyyv1IrsOrXYMqcDxcrnTLCdiVBW2UrlTbTXI20nECQ=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "c8ed404a13a5a97585e7310850110c0a768bd49c",
+        "rev": "b2ad0924ac458366a143e5ed1abff5cd15c0875f",
         "type": "github"
       },
       "original": {
@@ -928,11 +1012,11 @@
         "elisp-helpers": "elisp-helpers_2"
       },
       "locked": {
-        "lastModified": 1694004980,
-        "narHash": "sha256-0sESyIQigObvy14+qYMVIQaEnUila6zk8/PLAQ+4rRQ=",
+        "lastModified": 1726250271,
+        "narHash": "sha256-kyyv1IrsOrXYMqcDxcrnTLCdiVBW2UrlTbTXI20nECQ=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "1f8d955e5ca0ac87e6d079fb4f003a82bab721ae",
+        "rev": "b2ad0924ac458366a143e5ed1abff5cd15c0875f",
         "type": "github"
       },
       "original": {

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -91,6 +91,11 @@
         emacs-interactive = pkgs.callPackage ./interactive.nix {
           inherit (self.packages.${pkgs.system}) emacs;
         };
+
+        # An example of ELPA-compatible package archive
+        elpa-archive =
+          inputs.twist.lib.buildElpaArchive pkgs
+            self.packages.${pkgs.system}.emacs.packageInputs.dash;
       });
 
       homeConfigurations = eachSystem (

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -31,97 +31,103 @@
     emacs-builtins.url = "github:emacs-twist/emacs-builtins";
   };
 
-  outputs = {
-    nixpkgs,
-    systems,
-    emacs-ci,
-    self,
-    ...
-  } @ inputs: let
-    eachSystem = nixpkgs.lib.genAttrs (import systems);
+  outputs =
+    {
+      nixpkgs,
+      systems,
+      emacs-ci,
+      self,
+      ...
+    }@inputs:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
 
-    eachSystemPkgs = f:
-      nixpkgs.lib.genAttrs (import systems) (
+      eachSystemPkgs =
+        f:
+        nixpkgs.lib.genAttrs (import systems) (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              overlays = [
+                inputs.twist.overlays.default
+                (final: prev: {
+                  emacsPackage = emacs-ci.packages.${system}.emacs-snapshot;
+                })
+              ];
+            }
+          )
+        );
+    in
+    {
+      devShells = eachSystemPkgs (pkgs: {
+        default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.just
+          ];
+        };
+      });
+
+      packages = eachSystemPkgs (pkgs: {
+        emacs = pkgs.callPackage ./twist.nix {
+          inherit inputs;
+          inherit (pkgs) emacsPackage;
+        };
+
+        # With explicit buitlins
+        emacs-builtins = pkgs.callPackage ./twist.nix {
+          inherit inputs;
+          inherit (pkgs) emacsPackage;
+          initialLibraries = inputs.emacs-builtins.data.emacs-snapshot.libraries;
+        };
+
+        # Another test path to build the whole derivation (not with --dry-run).
+        emacs-wrapper = pkgs.callPackage ./twist-minimal.nix {
+          inherit (pkgs) emacsPackage;
+        };
+
+        # This is an example of interactive Emacs session.
+        # You can start Emacs by running `nix run .#emacs-interactive`.
+        emacs-interactive = pkgs.callPackage ./interactive.nix {
+          inherit (self.packages.${pkgs.system}) emacs;
+        };
+      });
+
+      homeConfigurations = eachSystem (
         system:
-          f (import nixpkgs {
-            inherit system;
-            overlays = [
-              inputs.twist.overlays.default
-              (final: prev: {
-                emacsPackage = emacs-ci.packages.${system}.emacs-snapshot;
-              })
-            ];
-          })
-      );
-  in {
-    devShells = eachSystemPkgs (pkgs: {
-      default = pkgs.mkShell {
-        buildInputs = [
-          pkgs.just
-        ];
-      };
-    });
-
-    packages = eachSystemPkgs (pkgs: {
-      emacs = pkgs.callPackage ./twist.nix {
-        inherit inputs;
-        inherit (pkgs) emacsPackage;
-      };
-
-      # With explicit buitlins
-      emacs-builtins = pkgs.callPackage ./twist.nix {
-        inherit inputs;
-        inherit (pkgs) emacsPackage;
-        initialLibraries = inputs.emacs-builtins.data.emacs-snapshot.libraries;
-      };
-
-      # Another test path to build the whole derivation (not with --dry-run).
-      emacs-wrapper = pkgs.callPackage ./twist-minimal.nix {
-        inherit (pkgs) emacsPackage;
-      };
-
-      # This is an example of interactive Emacs session.
-      # You can start Emacs by running `nix run .#emacs-interactive`.
-      emacs-interactive = pkgs.callPackage ./interactive.nix {
-        inherit (self.packages.${pkgs.system}) emacs;
-      };
-    });
-
-    homeConfigurations = eachSystem (
-      system:
         import ./home.nix rec {
           inherit inputs;
           pkgs = nixpkgs.legacyPackages.${system};
           inherit (nixpkgs) lib;
           inherit (self.packages.${system}) emacs;
         }
-    );
+      );
 
-    apps = eachSystem (
-      system:
+      apps = eachSystem (
+        system:
         self.packages.${system}.emacs.makeApps {
           lockDirName = "lock";
         }
-    );
+      );
 
-    checks = eachSystemPkgs (pkgs: {
-      symlink = pkgs.stdenv.mkDerivation {
-        name = "emacs-twist-wrapper-test";
-        src = self.packages.${pkgs.system}.emacs-wrapper;
-        doCheck = true;
-        checkPhase = ''
-          cd $src
-          tmp=$(mktemp)
-          echo "Checking missing symlinks"
-          find -L -type l | tee $tmp
-          [[ ! -s $tmp ]]
-          success=1
-        '';
-        installPhase = ''
-          [[ $success -eq 1 ]]
-          touch $out
-        '';
-      };
-    });
-  };
+      checks = eachSystemPkgs (pkgs: {
+        symlink = pkgs.stdenv.mkDerivation {
+          name = "emacs-twist-wrapper-test";
+          src = self.packages.${pkgs.system}.emacs-wrapper;
+          doCheck = true;
+          checkPhase = ''
+            cd $src
+            tmp=$(mktemp)
+            echo "Checking missing symlinks"
+            find -L -type l | tee $tmp
+            [[ ! -s $tmp ]]
+            success=1
+          '';
+          installPhase = ''
+            [[ $success -eq 1 ]]
+            touch $out
+          '';
+        };
+      });
+    };
 }

--- a/test/justfile
+++ b/test/justfile
@@ -79,5 +79,6 @@ test-home-manager: test-build
 
 other-checks: test-build
     nix build .\#checks.$(nix eval --expr builtins.currentSystem --raw --impure).symlink
+    nix build .\#packages.$(nix eval --expr builtins.currentSystem --raw --impure).elpa-archive
 
 test: check-attributes test-build other-checks test-home-manager

--- a/test/lock/archive.lock
+++ b/test/lock/archive.lock
@@ -1,9 +1,9 @@
 {
   "bbdb": {
     "archive": {
-      "narHash": "sha256-3kkU51Xd1nmPgAzwf4S95m6eZ9w15aLCDdVei6ZIJ7o=",
+      "narHash": "sha256-yR0Do+TbqsPi/uZMkcEXh2VEygAJMLRVS6NwT0VfIlI=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.2.tar"
+      "url": "https://elpa.gnu.org/packages/bbdb-3.2.2.4.tar"
     },
     "inventory": {
       "type": "archive",
@@ -13,30 +13,31 @@
       "cl-lib": "0.5",
       "emacs": "24"
     },
-    "version": "3.2.2.2"
+    "version": "3.2.2.4"
   },
   "dict-tree": {
     "archive": {
-      "narHash": "sha256-oOLncpjxAcSi5SBGCwr/2TCWdJwR1wQVyPBpZ2Wu/3I=",
+      "narHash": "sha256-ydD8+1MpaKhMAM0/1U8pylr7dSDjOFSRkKB6I2+Xywg=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/dict-tree-0.16.tar"
+      "url": "https://elpa.gnu.org/packages/dict-tree-0.17.tar"
     },
     "inventory": {
       "type": "archive",
       "url": "https://elpa.gnu.org/packages/"
     },
     "packageRequires": {
+      "emacs": "24.1",
       "heap": "0.3",
       "tNFA": "0.1.1",
-      "trie": "0.3"
+      "trie": "0.6"
     },
-    "version": "0.16"
+    "version": "0.17"
   },
   "heap": {
     "archive": {
-      "narHash": "sha256-sZ0BZW9/lEzeurBfd2nzh+5F+xOzrbBUozdxk3E0EkQ=",
-      "type": "file",
-      "url": "https://elpa.gnu.org/packages/heap-0.5.el"
+      "narHash": "sha256-LlBUyzpVQ6EkuiNjxhcURCH5v34KZ2Jbp48kBYnUEMg=",
+      "type": "tarball",
+      "url": "https://elpa.gnu.org/packages/heap-0.5.tar"
     },
     "inventory": {
       "type": "archive",
@@ -47,9 +48,9 @@
   },
   "ivy": {
     "archive": {
-      "narHash": "sha256-qoK7Sk3npmID1UD2BZ4IQGJpMtfmYpTXhrpz0/uJb6w=",
+      "narHash": "sha256-qUrUxYXkQ3aEtSfIM8XJ+YrOs6KeHCFYgshLWZHX2h4=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/ivy-0.13.4.tar"
+      "url": "https://elpa.gnu.org/packages/ivy-0.14.2.tar"
     },
     "inventory": {
       "type": "archive",
@@ -58,13 +59,13 @@
     "packageRequires": {
       "emacs": "24.5"
     },
-    "version": "0.13.4"
+    "version": "0.14.2"
   },
   "queue": {
     "archive": {
-      "narHash": "sha256-cbv1sqH7LJXdRZ/teyScnysvsn8/JcaPqrRBc7jGrZw=",
-      "type": "file",
-      "url": "https://elpa.gnu.org/packages/queue-0.2.el"
+      "narHash": "sha256-l1a18KhqXRtir2NSDVEY4yWGoUl97Vo9CvD1T9Jpw/Q=",
+      "type": "tarball",
+      "url": "https://elpa.gnu.org/packages/queue-0.2.tar"
     },
     "inventory": {
       "type": "archive",
@@ -90,9 +91,9 @@
   },
   "trie": {
     "archive": {
-      "narHash": "sha256-7Lrmt6zItGT8/Eee8SLBwzTaXEF3hRS7XigJP6n7UYI=",
+      "narHash": "sha256-FpkdWXrrgFEF/NHepkINHIlpYI72M+DaJwBg3r9GPMQ=",
       "type": "tarball",
-      "url": "https://elpa.gnu.org/packages/trie-0.5.tar"
+      "url": "https://elpa.gnu.org/packages/trie-0.6.tar"
     },
     "inventory": {
       "type": "archive",
@@ -102,6 +103,6 @@
       "heap": "0.3",
       "tNFA": "0.1.1"
     },
-    "version": "0.5"
+    "version": "0.6"
   }
 }

--- a/test/lock/flake.lock
+++ b/test/lock/flake.lock
@@ -19,11 +19,11 @@
     "compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673124789,
-        "narHash": "sha256-+DQRJqNi/W/25vp68LlTwut3a2uaLyn7+iit5gyHToA=",
+        "lastModified": 1725980821,
+        "narHash": "sha256-aW3v+8FYosGnRfavug90E/WpPfuz166q6DJwHvcdY5w=",
         "owner": "emacs-compat",
         "repo": "compat",
-        "rev": "887ec71fa3a90bc0d333ae9c333436148e909dbd",
+        "rev": "9a234d0d28cccd33f64faea6074fa2865a17c164",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "consult": {
       "flake": false,
       "locked": {
-        "lastModified": 1657948956,
-        "narHash": "sha256-VPtTbRUz1alW1wm9MlDYgKaHUUE+Vbam06OmVESzNI4=",
+        "lastModified": 1726330075,
+        "narHash": "sha256-aNZnTkdy+mtShiVcwxxYBXhiHzTCTsdO49eQuxUbGCo=",
         "owner": "minad",
         "repo": "consult",
-        "rev": "0fa264c2efc17e564af406d60dbe77ae2fb6f010",
+        "rev": "73530bab90dae79d6b0ea177b4e935588ea08dd1",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     "dash": {
       "flake": false,
       "locked": {
-        "lastModified": 1654716693,
-        "narHash": "sha256-ggJV5lX2F5T4FajFX8h3hT7YPZ2F11HDDeV9va8bJVI=",
+        "lastModified": 1715347628,
+        "narHash": "sha256-at42NCcdF9g7a55asnOCSqsvG+XhWuvVsHFT6kU9f9o=",
         "owner": "magnars",
         "repo": "dash.el",
-        "rev": "0ac1ecf6b56eb67bb81a3cf70f8d4354b5782341",
+        "rev": "1de9dcb83eacfb162b6d9a118a4770b1281bcd84",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     "doom-themes": {
       "flake": false,
       "locked": {
-        "lastModified": 1655939849,
-        "narHash": "sha256-mZNiAtAZ5dzbP8TakC6W2ivQnaDMdRxK4aYGCrRiF4g=",
+        "lastModified": 1725916625,
+        "narHash": "sha256-rV1iyHSjy6QGVrCwMIJQJjYXivl4ZBVgUwi0LTTsQxA=",
         "owner": "doomemacs",
         "repo": "themes",
-        "rev": "d79a41f593c69697af1ddaac971c0c47ecc446a8",
+        "rev": "1cac71a4b2434036496a49b4440fdba3d0b5b387",
         "type": "github"
       },
       "original": {
@@ -99,15 +99,16 @@
     "git-commit": {
       "flake": false,
       "locked": {
-        "lastModified": 1657072084,
-        "narHash": "sha256-pUZryPIJ4dVrNhJDvKucyx7lLTmZyv5mcAxr3cicrhc=",
+        "lastModified": 1725147338,
+        "narHash": "sha256-UWZehIqeHp41b93jwqfAjeKZRuv99AJQu2GP2yGSKQo=",
         "owner": "magit",
         "repo": "magit",
-        "rev": "acd26dd9f3708602d4c721395d790a4af7937eed",
+        "rev": "9be8a4ab7a7dc6f34615f1011e8da263651c8f87",
         "type": "github"
       },
       "original": {
         "owner": "magit",
+        "ref": "legacy-stub",
         "repo": "magit",
         "type": "github"
       }
@@ -115,11 +116,11 @@
     "google-translate": {
       "flake": false,
       "locked": {
-        "lastModified": 1617709095,
-        "narHash": "sha256-rvviaqVoigix3jd4ys2KN8nst//14tXn2/iz+46zP44=",
+        "lastModified": 1663728346,
+        "narHash": "sha256-Cl2n8Ea2zD3JqbQHtc2jIjejbzwRVsesYp+TZSPbgx8=",
         "owner": "atykhonov",
         "repo": "google-translate",
-        "rev": "0f7f48a09bca064999ecea03102a7c96f52cbd1b",
+        "rev": "e60dd6eeb9cdb931d9d8bfbefc29a48ef9a21bd9",
         "type": "github"
       },
       "original": {
@@ -131,11 +132,11 @@
     "magit": {
       "flake": false,
       "locked": {
-        "lastModified": 1657072084,
-        "narHash": "sha256-pUZryPIJ4dVrNhJDvKucyx7lLTmZyv5mcAxr3cicrhc=",
+        "lastModified": 1726496253,
+        "narHash": "sha256-giPhhvFRMtWpbo/W0Ca3mlrj6yd5AZPC50//WN2c0Iw=",
         "owner": "magit",
         "repo": "magit",
-        "rev": "acd26dd9f3708602d4c721395d790a4af7937eed",
+        "rev": "234a787b8caebbbbd647ed59a8cc519211ffd827",
         "type": "github"
       },
       "original": {
@@ -147,11 +148,11 @@
     "magit-section": {
       "flake": false,
       "locked": {
-        "lastModified": 1657072084,
-        "narHash": "sha256-pUZryPIJ4dVrNhJDvKucyx7lLTmZyv5mcAxr3cicrhc=",
+        "lastModified": 1726496253,
+        "narHash": "sha256-giPhhvFRMtWpbo/W0Ca3mlrj6yd5AZPC50//WN2c0Iw=",
         "owner": "magit",
         "repo": "magit",
-        "rev": "acd26dd9f3708602d4c721395d790a4af7937eed",
+        "rev": "234a787b8caebbbbd647ed59a8cc519211ffd827",
         "type": "github"
       },
       "original": {
@@ -163,11 +164,11 @@
     "org-transclusion": {
       "flake": false,
       "locked": {
-        "lastModified": 1655049139,
-        "narHash": "sha256-Ph+F5cA0gb7mXqeFP0pNTvdoa3KRBKB50qBobZAxU14=",
+        "lastModified": 1716224989,
+        "narHash": "sha256-ikRv0o/GJE3GimM2A/ArYaxotJEailRP6diPlN8mZqM=",
         "owner": "nobiot",
         "repo": "org-transclusion",
-        "rev": "5cb94542e18722bf72a281441e944a8039b5301f",
+        "rev": "e6e638710e90198070c9b07ebdaa345a79f74706",
         "type": "github"
       },
       "original": {
@@ -179,11 +180,11 @@
     "popup": {
       "flake": false,
       "locked": {
-        "lastModified": 1655402877,
-        "narHash": "sha256-aONVkKb9CVWvsLoQ8LIPNmJZ+6+a1oq+6DBrLrlDfK8=",
+        "lastModified": 1721548315,
+        "narHash": "sha256-q8hv+/tqOGEBpSjo8+iNweQfu00xu2QAguvgZaBl3Tg=",
         "owner": "auto-complete",
         "repo": "popup-el",
-        "rev": "c65905aa1a3ac32d1dbc8c1060605621e6143f80",
+        "rev": "c83d6e5f5fa693e08a542ea9ad7c06eced652de9",
         "type": "github"
       },
       "original": {
@@ -232,11 +233,11 @@
     "tramp": {
       "flake": false,
       "locked": {
-        "lastModified": 1672395337,
-        "narHash": "sha256-glJxoEs2yIRD7OeRxeE5ACYBnmJF/b1UzmIBmhNh0JQ=",
+        "lastModified": 1725016048,
+        "narHash": "sha256-lr20RJSqTGLpz0yO1us6oDjs2dQbc0tbp80B3/O92+E=",
         "ref": "externals/tramp",
-        "rev": "f1e00a4adb4de8f322f48cceec7e5c8bd3b298b6",
-        "revCount": 67,
+        "rev": "10d7de235368896ba3e1354f7869e92fb6b806fb",
+        "revCount": 87,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/tramp.git"
       },
@@ -265,11 +266,11 @@
     "vertico": {
       "flake": false,
       "locked": {
-        "lastModified": 1657450684,
-        "narHash": "sha256-aEFNH3r30ZkgPRDpcZtQBmSctu57w6k+q0LJVVSO1jg=",
+        "lastModified": 1726162291,
+        "narHash": "sha256-8oN469T925X+0Qf0faX9fdfdLEh94+CoNzUsRQ/XXrE=",
         "owner": "minad",
         "repo": "vertico",
-        "rev": "f222187a81d57332f9008bcbfbfefcfd2ae7e9c2",
+        "rev": "b8c9e39dbc39d2c4cd4e116c4bc6f835ed2f114b",
         "type": "github"
       },
       "original": {
@@ -281,11 +282,11 @@
     "with-editor": {
       "flake": false,
       "locked": {
-        "lastModified": 1654683454,
-        "narHash": "sha256-XWGXpF+2MSa6lrJdB4opguIffPst2o6ZI88cK/XUbQo=",
+        "lastModified": 1725143435,
+        "narHash": "sha256-+tDAxhliQJiKAZUVfX/bQbqjPEjB7p5jX7XoLf/5Bs0=",
         "owner": "magit",
         "repo": "with-editor",
-        "rev": "cfcbc2731e402b9169c0dc03e89b5b57aa988502",
+        "rev": "77cb2403158cfea9d8bfb8adad81b84d1d6d7c6a",
         "type": "github"
       },
       "original": {

--- a/test/lock/flake.nix
+++ b/test/lock/flake.nix
@@ -1,6 +1,5 @@
 {
-  description =
-    "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
+  description = "THIS IS AN AUTO-GENERATED FILE. PLEASE DON'T EDIT IT MANUALLY.";
   inputs = {
     async = {
       flake = false;
@@ -41,6 +40,7 @@
     git-commit = {
       flake = false;
       owner = "magit";
+      ref = "legacy-stub";
       repo = "magit";
       type = "github";
     };


### PR DESCRIPTION
This is an experimental feature for providing packages to platforms that don't support Nix (e.g. Windows without WSL).

With `lib.buildElpaArchive` function exposed from the flake, it builds a package archive that can be installed using `package-install-file`. The function takes the value of `packageInputs.*` attribute and builds a directory that contains the Emacs Lisp source files and `*-pkg.el` file in the same directory, so you can upload the artifact to a server. You also need to add a writable permission.

This is a fallback for non-Nix platforms. It is not recommended to use it daily, as there are extra overheads than the existing solution.