### PR TITLE
Add an option to suppress byte-compile

### DIFF
--- a/pkgs/emacs/build/default.nix
+++ b/pkgs/emacs/build/default.nix
@@ -14,6 +14,7 @@
   nativeCompileAhead,
   wantExtraOutputs,
   elispInputs,
+  dontByteCompile ? false,
   ...
 } @ attrs:
 with builtins; let
@@ -132,8 +133,8 @@ in
       lib.makeSearchPath "share/emacs/native-lisp/" elispInputs
     }:";
 
-    dontByteCompile = false;
     errorOnWarn = false;
+    inherit dontByteCompile;
 
     buildCmd = ''
       # Don't make the package description of package.el available


### PR DESCRIPTION
This is for convenience of suppressing byte-compilation without using `overrideAttrs`.