### PR TITLE
Expose a function to build a single Emacs Lisp package

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -41,4 +41,18 @@ in
       (split "\n")
       (filter (s: isString s && s != ""))
     ];
+
+  # A function that builds a single Emacs Lisp package. The argument should be
+  # an attribute set that takes the same form as an entry value in
+  # packageInputs. Most attributes for basic usage are self-explanatory, but it
+  # requires elispInputs, which is a list of derivations that contain Emacs Lisp
+  # source files in share/emacs/site-lisp directory and (optional)
+  # native-compiled libraries in share/emacs/native-lisp directory.
+  buildElispPackage =
+    pkgs:
+    pkgs.callPackage ../pkgs/emacs/build {
+      lib = import ../pkgs/build-support {
+        inherit inputs pkgs;
+      };
+    };
 }


### PR DESCRIPTION
This PR officially (though the library API may be changed in the future) exposes the function for building a single Emacs Lisp package, from the `lib` entry point of the flake.

The function should take two arguments: `pkgs`, i.e. `nixpkgs.legacyPackages.${system}`, and an attribute value from `packageInputs` in the config.

@terlar I am not sure if you still need this, but is it supposed to fix #65? 