### PR TITLE
fix: Include coreutils & git in 'lock' app's environment

### DIFF
--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -3,6 +3,7 @@
   nix,
   nixfmt-rfc-style,
   jq,
+  coreutils,
   runCommandLocal,
   writeTextFile,
   writeShellScript,
@@ -96,7 +97,7 @@ in {
     type = "app";
     program =
       (import ./write-lock-1.nix {inherit lib writeShellScript;} {
-        inherit outDir src postCommand;
+        inherit outDir src postCommand coreutils;
       })
       .outPath;
   };
@@ -104,6 +105,7 @@ in {
   writerScript = {postCommandOnGeneratingLockDir}:
     writeShellApplication {
       name = "emacs-twist-write-lock";
+      runtimeInputs = [ coreutils ];
       text =
         builtins.replaceStrings [
           "@lockSrcDir@"

--- a/pkgs/emacs/lock/write-lock-1.nix
+++ b/pkgs/emacs/lock/write-lock-1.nix
@@ -5,6 +5,7 @@
   outDir,
   src,
   postCommand,
+  coreutils,
 }:
 writeShellScript "lock" ''
   outDir="${outDir}"
@@ -27,7 +28,7 @@ writeShellScript "lock" ''
     fi
   done
 
-  install -m 644 -t "$outDir" ${src}/*.*
+  ${coreutils}/bin/install -m 644 -t "$outDir" ${src}/*.*
 
   ${lib.optionalString (postCommand != null) ''
     cd "$outDir"


### PR DESCRIPTION
hey @akirak :) thanks so much for all your hard work on twist - i am fascinated by the prospect of the project and am trying it out for building my configuration

---

This fixes an issue on Darwin systems where the native `install` command doesn't have a `-t` flag. Including `coreutils` in the script's runtimeInputs ensures that's the version of `install` the script uses, which fixes the problem.

I also took the liberty of adding `git`, as calls to git binaries are executed in the script.

I see there are also `nix` commands being executed, so we could also include that if we wanted, but perhaps that's not necessary and may introduce issues.