### PR TITLE
Lint on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.*'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.*'
+  workflow_dispatch:
+jobs:
+  lint:
+    uses: emacs-twist/internal/.github/workflows/check.yml@master
+    with:
+      package: linters

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.elisp-helpers.url = "github:emacs-twist/elisp-helpers";
 
-  outputs = {...} @ inputs: {
+  outputs = inputs: {
     # The APIs under lib is unstable at present. It may undergo changes in the
     # future.
     lib = import ./lib inputs;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -27,9 +27,6 @@ in
 
   emacsBuiltinLibraries =
     {
-      stdenv,
-      ripgrep,
-      emacs,
       lib,
     }@args:
     lib.pipe (readFile (import ../pkgs/emacs/builtins.nix args)) [

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -12,8 +12,6 @@ home-manager module that provides an installation of Emacs
 
   emacs-config = cfg.config;
 
-  configurationRevision = emacs-config.configurationRevision;
-
   initFile = pkgs.runCommandLocal "init.el" {} ''
     mkdir -p $out
     touch $out/init.el
@@ -45,7 +43,7 @@ home-manager module that provides an installation of Emacs
     '';
 
   desktopItem = pkgs.makeDesktopItem {
-    name = cfg.name;
+    inherit (cfg) name;
     inherit (cfg.desktopItem) desktopName mimeTypes;
     comment = "Edit text";
     genericName = "Text Editor";

--- a/pkgs/build-support/elisp/collectFromSetup.nix
+++ b/pkgs/build-support/elisp/collectFromSetup.nix
@@ -3,7 +3,7 @@ with builtins; let
   go = {
     data,
     rest,
-  } @ acc: fields: {
+  }: fields: {
     data =
       data
       ++ lib.pipe fields [

--- a/pkgs/build-support/elisp/flake.nix
+++ b/pkgs/build-support/elisp/flake.nix
@@ -2,7 +2,7 @@
   inputs.elisp-helpers.url = "github:emacs-twist/elisp-helpers";
 
   outputs =
-    { ... }:
+    _:
     {
     };
 }

--- a/pkgs/build-support/testToNix.nix
+++ b/pkgs/build-support/testToNix.nix
@@ -21,7 +21,7 @@ in
             type = "github";
           };
         };
-        outputs = {...}: {};
+        outputs = _: {};
       };
       expected = ''
         { description = "description"; inputs = { bind-key = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; "bind-key+" = { flake = false; owner = "jwiegley"; repo = "use-package"; type = "github"; }; }; outputs = <LAMBDA>; }'';

--- a/pkgs/build-support/toNix.nix
+++ b/pkgs/build-support/toNix.nix
@@ -4,8 +4,6 @@
 {lib}: let
   inherit (builtins) isList isAttrs isFunction toJSON concatStringsSep match;
 
-  isPrimitive = v: ! (isList v || isAttrs v || isFunction v);
-
   wrap = open: close: body: open + body + close;
 
   printList = v:

--- a/pkgs/emacs/data/default.nix
+++ b/pkgs/emacs/data/default.nix
@@ -6,11 +6,8 @@ let
     tail
     hasAttr
     filter
-    elem
     mapAttrs
-    readFile
     pathExists
-    concatLists
     isFunction
     removeAttrs
     attrNames

--- a/pkgs/emacs/data/inventory/elpa.nix
+++ b/pkgs/emacs/data/inventory/elpa.nix
@@ -27,7 +27,7 @@ with builtins;
         lib.pipe elpaEntries [
           (lib.filterAttrs (_: entry: entry ? core))
           (lib.mapAttrs (
-            _: {core, ...} @ entry: {
+            _: {core, ...}: {
               inherit inventory;
               src = args.core-src;
               doTangle = true;

--- a/pkgs/emacs/data/package.nix
+++ b/pkgs/emacs/data/package.nix
@@ -2,19 +2,11 @@ let
   inherit
     (builtins)
     pathExists
-    fetchTree
-    replaceStrings
-    map
-    readDir
     hasAttr
     readFile
     attrNames
     filter
-    all
     match
-    isString
-    isList
-    typeOf
     length
     head
     toJSON
@@ -120,10 +112,7 @@ in
       ];
 
       mainFile =
-        if attrs ? mainFile
-        then attrs.mainFile
-        else
-          lib.findFirst
+        attrs.mainFile or (lib.findFirst
           (file: baseNameOf file == ename + ".el")
           (
             if length self.lispFiles > 0
@@ -136,7 +125,7 @@ in
                 Entry: ${toJSON attrs.inventory}
               ''
           )
-          self.lispFiles;
+          self.lispFiles);
 
       # TODO: Check https://github.com/melpa/melpa/issues/2955 on the right versioning scheme
       version =

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -54,15 +54,12 @@
     (builtins)
     readFile
     attrNames
-    attrValues
     concatLists
     isFunction
     split
     filter
     isString
     mapAttrs
-    match
-    isList
     isAttrs
     elem
     removeAttrs

--- a/pkgs/emacs/default.nix
+++ b/pkgs/emacs/default.nix
@@ -148,9 +148,7 @@ in
       }
       packageInputs;
 
-    generateLockFiles = self.callPackage ./lock {
-      inherit flakeLockFile;
-    };
+    generateLockFiles = self.callPackage ./lock { };
 
     excludeLocalPackages = attrs: removeAttrs attrs localPackages;
   in {

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -1,15 +1,12 @@
 {
   lib,
-  nix,
   nixfmt-rfc-style,
   jq,
   coreutils,
   runCommandLocal,
-  writeTextFile,
   writeShellScript,
   writeShellApplication,
   # Current version
-  flakeLockFile ? null,
 }: {
   packageInputs,
   flakeNix ? false,
@@ -19,7 +16,7 @@
   postCommand ? null,
 }:
 assert (flakeNix || archiveLock); let
-  inherit (builtins) toJSON attrNames mapAttrs;
+  inherit (builtins) toJSON mapAttrs;
 
   archiveLockData = lib.pipe packageInputs [
     (lib.filterAttrs (_: attrs: attrs ? archive))
@@ -50,7 +47,7 @@ assert (flakeNix || archiveLock); let
         (lib.filterAttrs (_: attrs: attrs ? origin))
         (lib.mapAttrs (_: {origin, ...}: origin // {flake = false;}))
       ];
-      outputs = {...}: {};
+      outputs = _: {};
     };
     archiveLock = toJSON archiveLockData;
     metadataJson = toJSON packageMetadata;

--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -6,7 +6,6 @@
   runCommandLocal,
   writeShellScript,
   writeShellApplication,
-  # Current version
 }: {
   packageInputs,
   flakeNix ? false,

--- a/pkgs/emacs/tools/check-versions.nix
+++ b/pkgs/emacs/tools/check-versions.nix
@@ -9,7 +9,6 @@
   inherit
     (builtins)
     mapAttrs
-    all
     hasAttr
     elem
     length
@@ -18,7 +17,6 @@
     substring
     lessThan
     concatLists
-    sort
     concatStringsSep
     attrNames
     ;
@@ -90,9 +88,9 @@
           }
           // status)))
       concatLists
-      (lib.groupBy ({ename, ...}: ename))
-      (mapAttrs (ename: statuses: {
-        current = (head statuses).current;
+      (builtins.groupBy ({ename, ...}: ename))
+      (mapAttrs (_ename: statuses: {
+        inherit ((head statuses)) current;
         # Showing the source date may be useful, but maybe later.
         #
         # lastModifiedDate =

--- a/pkgs/emacs/tools/reverse.nix
+++ b/pkgs/emacs/tools/reverse.nix
@@ -1,6 +1,6 @@
 # Reverse dependencies of elisp packages
 {lib}: packageInputs: let
-  inherit (builtins) attrNames hasAttr mapAttrs substring;
+  inherit (builtins) mapAttrs substring;
 
   revDeps = name:
     lib.concatMapAttrs (

--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -15,7 +15,7 @@
   configurationRevision,
   extraSiteStartElisp,
 }: let
-  inherit (builtins) length listToAttrs;
+  inherit (builtins) length;
 
   elispInputs = lib.attrVals packageNames elispPackages;
 

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -31,7 +31,6 @@
   };
 
   outputs = {
-    self,
     nixpkgs,
     nixpkgs-emacs,
     flake-utils,

--- a/test/flake.nix
+++ b/test/flake.nix
@@ -50,7 +50,7 @@
             import nixpkgs {
               inherit system;
               overlays = [
-                (final: prev: {
+                (_final: _prev: {
                   emacsPackage = emacs-ci.packages.${system}.emacs-snapshot;
                 })
               ];

--- a/test/lock/flake.nix
+++ b/test/lock/flake.nix
@@ -104,5 +104,5 @@
       type = "github";
     };
   };
-  outputs = { ... }: { };
+  outputs = _: { };
 }


### PR DESCRIPTION
This PR adds a workflow for linting without adding dependencies to the code base. Formatters won't be run, because `nixfmt-rfc-style` would break git-blame on the existing code base.