### PR TITLE
fix(build): prefix load paths instead of set

### DIFF
--- a/pkgs/emacs/wrapper.nix
+++ b/pkgs/emacs/wrapper.nix
@@ -182,7 +182,7 @@ in
         ${lib.optionalString (length executablePackages > 0) "--prefix PATH : ${lib.escapeShellArg (lib.makeBinPath executablePackages)}"} \
         --prefix INFOPATH : ${emacs}/share/info:$out/share/info:${infoPath} \
         ${
-      lib.optionalString nativeComp "--set EMACSNATIVELOADPATH $nativeLisp:$nativeLoadPath"
+      lib.optionalString nativeComp "--prefix EMACSNATIVELOADPATH : $nativeLisp:$nativeLoadPath"
     } \
         --set EMACSLOADPATH "$siteLisp:"
       fi


### PR DESCRIPTION
Allows callers to add their `EMACSNATIVELOADPATH`. This is a workaround for a bug where `--init-directory` is set after the user eln cache is set up. By allowing the caller to add the eln cache directory in the env variable, emacs will be able to discover the byte compiled `{early-}init.el` files.