### PR TITLE
Enable cachix on CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,32 @@
+name: Set up Nix
+
+description: Set up Nix
+
+inputs:
+  cachix-token:
+    description: Auth token for cachix
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: nixbuild/nix-quick-install-action@63ca48f939ee3b8d835f4126562537df0fee5b91 # v32
+      with:
+        nix_conf: |
+          keep-env-derivations = true
+          keep-outputs = true
+          accept-flake-config = true
+
+    - name: Restore the package cache
+      uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 1G
+
+    - uses: cachix/cachix-action@v16
+      with:
+        name: emacs-twist
+        authToken: '${{ inputs.cachix-token }}'
+        # Push all dependencies, including sources
+        useDaemon: false

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v31
+
+    - name: Set up Nix
+      uses: ./.github/actions/setup
       with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          accept-flake-config = true
+        cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - name: Update the flake inputs for the test
       run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,9 +27,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v31
+
+    - name: Set up Nix
+      uses: ./.github/actions/setup
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        cachix-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
     - run: nix flake update
       working-directory: pkgs/build-support/elisp


### PR DESCRIPTION
Set up a reusable action on CI. Switch to nix-quick-install-action + cachx-nix-action for faster CI runs. Also cachix to store sources. gnu.org is sometimes down nowadays.