### PR TITLE
rename nixfmt-rfc-style to nixfmt

### DIFF
--- a/pkgs/emacs/lock/default.nix
+++ b/pkgs/emacs/lock/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  nixfmt-rfc-style,
+  nixfmt,
   jq,
   coreutils,
   runCommandLocal,
@@ -63,7 +63,7 @@ assert (flakeNix || archiveLock); let
   # proper Nix, but it is troublesome to run a nested Nix during a build phase.
   generateFlakeNix = ''
     sed -e 's/<LAMBDA>/{ ... }: { }/' $flakeNixPath > "$out/flake.nix"
-    ${nixfmt-rfc-style}/bin/nixfmt "$out/flake.nix"
+    ${nixfmt}/bin/nixfmt "$out/flake.nix"
   '';
 
   generateArchiveLock = ''


### PR DESCRIPTION
`nixfmt-rfc-style` has been renamed to `nixfmt` in Nixpkgs.
Using the old name currently triggers the following evaluation warning:
`warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.`

This PR updates the reference to use `nixfmt` directly to suppress the warning.