### PR TITLE
fix(home-manager): drop deprecated lib.mdDoc and fix doc typo

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -96,8 +96,8 @@ in {
 
       manifestFileName = mkOption {
         type = types.str;
-        description = lib.mdDoc ''
-          Name of the manifest file, relative from `user-emacs-directory.
+        description = ''
+          Name of the manifest file, relative from `user-emacs-directory`.
 
           This is necessary to enable hot reloading of packages.
         '';
@@ -127,9 +127,9 @@ in {
       };
 
       serviceIntegration = {
-        enable = mkEnableOption (lib.mdDoc ''
+        enable = mkEnableOption ''
           Enable service integration. For now, only systemd is supported.
-        '');
+        '';
       };
 
       icons = {


### PR DESCRIPTION
`lib.mdDoc` has been a no-op since nixpkgs 23.11 and is being removed, so drop the two remaining uses. Also close the unterminated inline code span in the manifestFileName description (`user-emacs-directory`).

https://github.com/NixOS/nixpkgs/issues/300735