### PR TITLE
fix(ci): enable globstar so all unit tests run

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,5 +44,6 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
+          shopt -s globstar nullglob
           nix-instantiate --strict --eval --json pkgs/build-support/**/test*.nix \
           | jq

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
-          shopt -s globstar nullglob
-          nix-instantiate --strict --eval --json pkgs/build-support/**/test*.nix \
-          | jq
+
+          tests=()
+          while IFS= read -r -d '' test; do
+            tests+=("$test")
+          done < <(find pkgs/build-support -type f -name 'test*.nix' -print0)
+
+          nix-instantiate --strict --eval --json "${tests[@]}" | jq


### PR DESCRIPTION
GitHub Actions runs Bash steps as `bash --noprofile --norc -eo pipefail` ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell)), and this workflow never enables globstar.

As a result, pkgs/build-support/**/test*.nix is expanded as a single-directory glob rather than recursively, so tests located directly under pkgs/build-support/ (e.g. testGitUrlToAttrs.nix and testToNix.nix) are not included in the nix-instantiate invocation.

Enabling globstar (and nullglob) ensures the full test set is evaluated.