### PR TITLE
fix: restore native compilation on Emacs versions before 30

### DIFF
--- a/pkgs/emacs/build/comp-native.el
+++ b/pkgs/emacs/build/comp-native.el
@@ -4,7 +4,9 @@
 ;;
 ;; Based on code from https://www.emacswiki.org/emacs/GccEmacs#h5o-14
 
-(require 'comp-run)
+;; comp-run.el was split out of comp.el in Emacs 30.
+(unless (require 'comp-run nil t)
+  (require 'comp))
 
 (if (fboundp 'comp--async-runnings)
     (defalias 'twist--comp-async-runnings #'comp--async-runnings)


### PR DESCRIPTION
Since `comp-run.el` was split out from `comp.el` in Emacs 30, requiring it unconditionally breaks native compilation on Emacs 28/29. This fix therefore needs to support Emacs 28 and 29 as well.

related:
- https://github.com/emacs-twist/twist.nix/issues/161
-  3aeeae4 