### PR TITLE
fix(lock): repair the dead Git working tree check in the lock writer

### DIFF
--- a/pkgs/emacs/lock/write-lock-2.bash
+++ b/pkgs/emacs/lock/write-lock-2.bash
@@ -56,8 +56,9 @@ function checkSettings() {
 
   local parent
   parent=$(dirname "$outDir")
-  if [[ $( cd "$parent" && git-rev-parse --is-inside-work-tree 2>/dev/null ) = true ]]; then
+  if [[ $( cd "$parent" && git rev-parse --is-inside-work-tree 2>/dev/null ) != true ]]; then
     err "Directory $outDir is not inside a Git working tree"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
`checkSettings()` in `write-lock-2.bash` is meant to reject an output directory
whose parent isn't inside a Git working tree (the writer relies on `git add` /
`git ls-files`). It never fired:

- `git-rev-parse` (dashed) isn't on `PATH`, so `2>/dev/null` swallowed a
  "command not found" and the substitution was always empty;
- the condition `= true` was inverted (it should reject when *not* in a work
  tree);
- and there was no `exit`, so it continued anyway.

This uses `git rev-parse`, flips the test to `!= true`, and adds `exit 1`, so a
bad target now fails fast with a clear message instead of erroring later inside
`copyFiles()`. Impact is small: this script is only reached via
`generateLockDir`, not the `.#lock` / `.#update` apps.

Question: is `generateLockDir` / `writerScript` still something you intend to
keep? It doesn't seem wired into `makeApps` or used by the emacs-config
consumers I looked at — if you'd rather retire it, I'll drop this instead.