### PR TITLE
fix: stringify flake.lock version in error messages

### DIFF
--- a/pkgs/emacs/data/default.nix
+++ b/pkgs/emacs/data/default.nix
@@ -34,7 +34,7 @@ in
     }:
       if version == 7
       then lib.mapAttrs (_: {locked, ...}: locked) nodes
-      else throw "Unsupported flake.lock version ${version}";
+      else throw "Unsupported flake.lock version ${toString version}";
 
     flakeLockData =
       if pathExists flakeLockFile

--- a/pkgs/emacs/lock/flake-lock.nix
+++ b/pkgs/emacs/lock/flake-lock.nix
@@ -31,4 +31,4 @@
 in
   if prev.version == 7
   then version7
-  else throw "Unsupported flake.lock version ${prev.version}"
+  else throw "Unsupported flake.lock version ${toString prev.version}"


### PR DESCRIPTION
`version` is an integer, so `"...${version}"` throws `cannot coerce an integer to
a string` instead of the intended "Unsupported flake.lock version N". Wrap it in
`toString`. (Not hit in normal use since current locks are version 7; matters
when the schema is bumped.)